### PR TITLE
Fix/hono quick

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "chiitiler",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Tiny map rendering server for MapLibre Style Spec",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -80,7 +80,7 @@ describe('initServer', () => {
         const res2 = await app.request(
             '/clip.gif?bbox=0,1,2,3&url=file://localdata/style.json',
         );
-        expect(res2.status).toBe(404); // invalid format will not be handled in /clip
+        expect(res2.status).toBe(400); // invalid format will not be handled in /clip
 
         const res3 = await app.request(
             'clip.png?bbox=0,0,0,0&url=file://localdata/style.json',

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono } from 'hono/quick';
 import { serve } from '@hono/node-server';
 import {
     type StyleSpecification,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -117,9 +117,10 @@ function initServer(options: InitServerOptions) {
         });
 
     const clip = new Hono()
-        .get('/:filename{clip\\.png|webp|jpeg|jpg$}', async (c) => {
+        .get('/:filename_ext', async (c) => {
             // path params
-            const [_, ext] = c.req.param('filename').split('.');
+            const [filename, ext] = c.req.param('filename_ext').split('.');
+            if (filename !== 'clip') return c.body('not found', 404);
             if (!isSupportedFormat(ext)) return c.body('invalid format', 400);
 
             // query params
@@ -150,14 +151,15 @@ function initServer(options: InitServerOptions) {
                 return c.body('failed to render bbox', 400);
             }
         })
-        .post('/:filename{clip\\.png|webp|jpeg|jpg$}', async (c) => {
+        .post('/:filename_ext', async (c) => {
             // body
             const { style } = await c.req.json();
             if (!isValidStylejson(style))
                 return c.body('invalid stylejson', 400);
 
             // path params
-            const [_, ext] = c.req.param('filename').split('.');
+            const [filename, ext] = c.req.param('filename_ext').split('.');
+            if (filename !== 'clip') return c.body('not found', 404);
             if (!isSupportedFormat(ext)) return c.body('invalid format', 400);
 
             // query params


### PR DESCRIPTION
https://github.com/honojs/hono/issues/1109

`hono/quick` seems to be faster in routing for 30ms.
This change omits regex in routing but regex is not essential part for this server.
Launching time is much critical because chiitiler aims to be easy to scale out.