### PR TITLE
feat: support gcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ you can pass server options via environment variables
 | CHIITILER_GCS_BUCKET               |          | gcs cache bucket name                          |
 | CHIITILER_GCS_PROJECT_ID           |          | gcs project id                                 |
 | CHIITILER_GCS_KEY_FILENAME         |          | gcs key filename                               |
+| CHIITILER_GCS_PREFIX               |          | gcs cache prefix                               |
 
 ### debug page
 
@@ -291,8 +292,6 @@ const s3Cache = ChiitilerCache.s3Cache({
 
 const gcsCache = ChiitilerCache.gcsCache({
     bucket: 'chiitiler',
-    projectId: 'your-project-id',
-    keyFilename: '/path/to/key.json',
 });
 // credentials are loaded from environment variables: GOOGLE_APPLICATION_CREDENTIALS
 

--- a/README.md
+++ b/README.md
@@ -321,4 +321,5 @@ const bboxBuf = await getRenderedBboxBuffer({
 
 ## development
 
-- run `docker compose up`
+- To debug S3, run `docker compose up`
+- To debug GCS, change `CHIITILER_CACHE_METHOD` to `gcs` in `docker-compose.yml`, and then run `docker compose up`

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ you can pass server options via environment variables
 | CHIITILER_PROCESSES                | 1        | num of chiitiler processes. 0 means all-CPUs   |
 | CHIITILER_DEBUG                    | false    | debug mode                                     |
 | CHIITILER_STREAM_MODE              | false    | stream mode                                    |
-| CHIITILER_CACHE_METHOD             | none     | cache method, `none`, `memory`, `file` or `s3` |
+| CHIITILER_CACHE_METHOD             | none     | cache method, `none`, `memory`, `file`, `s3` or `gcs` |
 | CHIITILER_CACHE_TTL_SEC            | 3600     | cache ttl, effect to `memory` and `file`       |
 | CHIITILER_MEMORYCACHE_MAXITEMCOUNT | 1000     | max items for memorycache                      |
 | CHIITILER_FILECACHE_DIR            | .cache   | filecache directory                            |
@@ -107,6 +107,9 @@ you can pass server options via environment variables
 | CHIITILER_S3_REGION                | us-east1 | s3 bucket region for caching/fetching          |
 | CHIITILER_S3_ENDPOINT              |          | s3 endpoint for caching/fetching               |
 | CHIITILER_S3_FORCE_PATH_STYLE      | false    | force path style for s3, needed for minio      |
+| CHIITILER_GCS_BUCKET               |          | gcs cache bucket name                          |
+| CHIITILER_GCS_PROJECT_ID           |          | gcs project id                                 |
+| CHIITILER_GCS_KEY_FILENAME         |          | gcs key filename                               |
 
 ### debug page
 
@@ -126,6 +129,7 @@ you can pass server options via environment variables
 - `http://` or `https://` protocol are used in Style Specification
 - In addition, chiitiler supports following protocols:
   - `s3://` for S3 bucket
+  - `gs://` for Google Cloud Storage bucket
   - `file://` for file system
   - `mbtiles://` for MBTIles files
   - `pmtiles://` for PMTiles, remote or local or s3
@@ -165,6 +169,13 @@ you can pass server options via environment variables
       "type": "vector",
       "tiles": [
         "s3://tiles/{z}/{x}/{y}.pbf"
+      ],
+      "maxzoom": 6
+    },
+    "gcs": {
+      "type": "vector",
+      "tiles": [
+        "gs://tiles/{z}/{x}/{y}.pbf"
       ],
       "maxzoom": 6
     },
@@ -218,6 +229,26 @@ you can pass server options via environment variables
       }
     },
     {
+      "id": "pmtiles-s3",
+      "source": "pmtiles-s3",
+      "source-layer": "P2921",
+      "type": "circle",
+      "paint": {
+        "circle-radius": 3,
+        "circle-color": "purple"
+      }
+    },
+    {
+      "id": "gcs",
+      "source": "gcs",
+      "source-layer": "P2921",
+      "type": "circle",
+      "paint": {
+        "circle-radius": 3,
+        "circle-color": "purple"
+      }
+    },
+    {
       "id": "cog",
       "source": "cog",
       "type": "raster",
@@ -257,6 +288,13 @@ const s3Cache = ChiitilerCache.s3Cache({
     endpoint: null,
 });
 // credentials are loaded from environment variables: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+
+const gcsCache = ChiitilerCache.gcsCache({
+    bucket: 'chiitiler',
+    projectId: 'your-project-id',
+    keyFilename: '/path/to/key.json',
+});
+// credentials are loaded from environment variables: GOOGLE_APPLICATION_CREDENTIALS
 
 const tileBuf = await getRenderedTileBuffer({
     stylejson: 'https://example.com/style.json', // or StyleSpecification object

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ you can pass server options via environment variables
 | CHIITILER_GCS_CACHE_PREFIX         |          | gcs cache prefix                               |
 | CHIITILER_GCS_PROJECT_ID           |          | gcs project id                                 |
 | CHIITILER_GCS_KEY_FILENAME         |          | gcs key filename                               |
+| CHIITILER_GCS_API_ENDPOINT         |          | gcs api endpoint                               |
 
 ### debug page
 

--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ you can pass server options via environment variables
 | CHIITILER_S3_REGION                | us-east1 | s3 bucket region for caching/fetching          |
 | CHIITILER_S3_ENDPOINT              |          | s3 endpoint for caching/fetching               |
 | CHIITILER_S3_FORCE_PATH_STYLE      | false    | force path style for s3, needed for minio      |
-| CHIITILER_GCS_BUCKET               |          | gcs cache bucket name                          |
+| CHIITILER_GCS_CACHE_BUCKE          |          | gcs cache bucket name                          |
+| CHIITILER_GCS_CACHE_PREFIX         |          | gcs cache prefix                               |
 | CHIITILER_GCS_PROJECT_ID           |          | gcs project id                                 |
 | CHIITILER_GCS_KEY_FILENAME         |          | gcs key filename                               |
-| CHIITILER_GCS_PREFIX               |          | gcs cache prefix                               |
 
 ### debug page
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
             - CHIITILER_STREAM_MODE=true
             - AWS_ACCESS_KEY_ID=minioadmin
             - AWS_SECRET_ACCESS_KEY=minioadmin
+            - STORAGE_EMULATOR_HOST=http://fake-gcs-server:4443
+            - CHIITILER_GCS_BUCKET=tiles
     minio:
         image: minio/minio:latest
         ports:
@@ -51,3 +53,10 @@ services:
             "
         volumes:
             - ./localdata:/initdata
+    fake-gcs-server:
+        image: fsouza/fake-gcs-server:latest
+        ports:
+            - "4443:4443"
+        volumes:
+            - ./localdata:/data/tiles
+        command: -scheme http

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
             - AWS_ACCESS_KEY_ID=minioadmin
             - AWS_SECRET_ACCESS_KEY=minioadmin
             - STORAGE_EMULATOR_HOST=http://fake-gcs-server:4443
-            - CHIITILER_GCS_BUCKET=tiles
+            - CHIITILER_GCS_CACHE_BUCKET=tiles
     minio:
         image: minio/minio:latest
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
             - CHIITILER_STREAM_MODE=true
             - AWS_ACCESS_KEY_ID=minioadmin
             - AWS_SECRET_ACCESS_KEY=minioadmin
-            - STORAGE_EMULATOR_HOST=http://fake-gcs-server:4443
+            - CHIITILER_GCS_API_ENDPOINT=http://fake-gcs-server:4443
             - CHIITILER_GCS_CACHE_BUCKET=tiles
     minio:
         image: minio/minio:latest
@@ -58,5 +58,5 @@ services:
         ports:
             - "4443:4443"
         volumes:
-            - ./localdata:/data/tiles
+            - ./localdata/tiles:/data/tiles
         command: -scheme http

--- a/localdata/style.json
+++ b/localdata/style.json
@@ -71,7 +71,7 @@
       "source-layer": "P2921",
       "type": "circle",
       "paint": {
-        "circle-radius": 20,
+        "circle-radius": 25,
         "circle-color": "red"
       }
     },
@@ -81,7 +81,7 @@
       "source-layer": "P2921",
       "type": "circle",
       "paint": {
-        "circle-radius": 15,
+        "circle-radius": 20,
         "circle-color": "blue"
       }
     },
@@ -91,7 +91,7 @@
       "source-layer": "P2921",
       "type": "circle",
       "paint": {
-        "circle-radius": 10,
+        "circle-radius": 15,
         "circle-color": "yellow"
       }
     },
@@ -101,7 +101,7 @@
       "source-layer": "P2921",
       "type": "circle",
       "paint": {
-        "circle-radius": 5,
+        "circle-radius": 10,
         "circle-color": "green"
       }
     },
@@ -111,7 +111,7 @@
       "source-layer": "P2921",
       "type": "circle",
       "paint": {
-        "circle-radius": 3,
+        "circle-radius": 5,
         "circle-color": "purple"
       }
     },
@@ -122,7 +122,7 @@
       "type": "circle",
       "paint": {
         "circle-radius": 3,
-        "circle-color": "purple"
+        "circle-color": "orange"
       }
     },
     {

--- a/localdata/style.json
+++ b/localdata/style.json
@@ -36,6 +36,13 @@
       ],
       "maxzoom": 6
     },
+    "gcs": {
+      "type": "vector",
+      "tiles": [
+        "gs://tiles/{z}/{x}/{y}.pbf"
+      ],
+      "maxzoom": 6
+    },
     "pmtiles-s3": {
       "type": "vector",
       "tiles": [
@@ -101,6 +108,16 @@
     {
       "id": "pmtiles-s3",
       "source": "pmtiles-s3",
+      "source-layer": "P2921",
+      "type": "circle",
+      "paint": {
+        "circle-radius": 3,
+        "circle-color": "purple"
+      }
+    },
+    {
+      "id": "gcs",
+      "source": "gcs",
       "source-layer": "P2921",
       "type": "circle",
       "paint": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 	},
 	"dependencies": {
 		"@aws-sdk/client-s3": "^3.418.0",
+		"@google-cloud/storage": "^7.15.2",
 		"@hono/node-server": "^1.12.0",
 		"@mapbox/sphericalmercator": "^1.2.0",
 		"@mapbox/tilebelt": "^1.0.2",

--- a/src/cache/gcs.ts
+++ b/src/cache/gcs.ts
@@ -3,9 +3,9 @@ import { getStorageClient } from '../gcs.js';
 
 type GCSCacheOptions = {
     bucket: string;
+    prefix?: string;
     projectId?: string;
     keyFilename?: string;
-    prefix?: string;
 };
 
 function gcsCache(options: GCSCacheOptions): Cache {

--- a/src/cache/gcs.ts
+++ b/src/cache/gcs.ts
@@ -1,0 +1,64 @@
+import { type Cache, type Value } from './index.js';
+import { getStorageClient } from '../gcs.js';
+
+type GCSCacheOptions = {
+    bucket: string;
+    projectId?: string;
+    keyFilename?: string;
+};
+
+function gcsCache(options: GCSCacheOptions): Cache {
+    const storageClient = getStorageClient({
+        projectId: options.projectId,
+        keyFilename: options.keyFilename,
+    });
+    const bucket = storageClient.bucket(options.bucket);
+
+    return {
+        name: 'gcs',
+        set: async function (key: string, value: Value) {
+            try {
+                const file = bucket.file(escapeFileName(key));
+                await file.save(value);
+            } catch (e) {
+                console.log(`[error]: ${e}`);
+            }
+        },
+        get: async function (key: string): Promise<Value | undefined> {
+            const file = bucket.file(escapeFileName(key));
+            try {
+                const [buffer] = await file.download();
+                return buffer;
+            } catch (e) {
+                // miss or any error
+                return undefined;
+            }
+        },
+    };
+}
+
+function escapeFileName(url: string) {
+    return url
+        .replace(/\//g, '_') // replace slashes with underscores
+        .replace(/\?/g, '-') // replace question marks with dashes
+        .replace(/&/g, '-') // replace ampersands with dashes
+        .replace(/=/g, '-') // replace equals signs with dashes
+        .replace(/%/g, '-') // replace percent signs with dashes
+        .replace(/#/g, '-') // replace hash signs with dashes
+        .replace(/:/g, '-') // replace colons with dashes
+        .replace(/\+/g, '-') // replace plus signs with dashes
+        .replace(/ /g, '-') // replace spaces with dashes
+        .replace(/</g, '-') // replace less than signs with dashes
+        .replace(/>/g, '-') // replace greater than signs with dashes
+        .replace(/\*/g, '-') // replace asterisks with dashes
+        .replace(/\|/g, '-') // replace vertical bars with dashes
+        .replace(/"/g, '-') // replace double quotes with dashes
+        .replace(/'/g, '-') // replace single quotes with dashes
+        .replace(/\?/g, '-') // replace question marks with dashes
+        .replace(/\./g, '-') // replace dots with dashes
+        .replace(/,/g, '-') // replace commas with dashes
+        .replace(/;/g, '-') // replace semicolons with dashes
+        .replace(/\\/g, '-'); // replace backslashes with dashes
+}
+
+export { gcsCache };

--- a/src/cache/gcs.ts
+++ b/src/cache/gcs.ts
@@ -26,7 +26,9 @@ function gcsCache(options: GCSCacheOptions): Cache {
             const file = bucket.file(nameWithPrefix);
 
             try {
-                await file.save(value);
+                await file.save(value, {
+                    resumable: false,
+                });
             } catch (e) {
                 console.log(`[error]: ${e}`);
             }

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,5 +1,6 @@
 import { memoryCache } from './memory.js';
 import { s3Cache } from './s3.js';
+import { gcsCache } from './gcs.js';
 import { fileCache } from './file.js';
 
 type Value = Buffer;
@@ -15,4 +16,4 @@ const noneCache: () => Cache = () => ({
     set: async () => undefined,
 });
 
-export { noneCache, memoryCache, s3Cache, fileCache, type Value, type Cache };
+export { noneCache, memoryCache, s3Cache, gcsCache, fileCache, type Value, type Cache };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,9 +16,9 @@ function parseCacheStrategy(
         s3Endpoint: string;
         s3ForcePathStyle: boolean;
         gcsCacheBucket: string;
+        gcsCachePrefix: string;
         gcsProjectId: string;
         gcsKeyFilename: string;
-        gcsCachePrefix: string;
     },
 ) {
     // command-line option
@@ -71,10 +71,10 @@ function parseCacheStrategy(
         });
     if (cacheEnv === 'gcs')
         return caches.gcsCache({
-            bucket: process.env.CHIITILER_GCS_BUCKET ?? '',
+            bucket: process.env.CHIITILER_GCS_CACHE_BUCKET ?? '',
+            prefix: process.env.CHIITILER_GCS_CACHE_PREFIX ?? '',
             projectId: process.env.CHIITILER_GCS_PROJECT_ID ?? '',
             keyFilename: process.env.CHIITILER_GCS_KEY_FILENAME ?? '',
-            prefix: process.env.CHIITILER_GCS_PREFIX ?? '',
         });
 
     // undefined or invalid
@@ -181,9 +181,9 @@ export function createProgram() {
                     s3Endpoint: options.s3Endpoint,
                     s3ForcePathStyle: options.s3ForcePathStyle === 'true',
                     gcsCacheBucket: options.gcsCacheBucket,
+                    gcsCachePrefix: options.gcsCachePrefix,
                     gcsProjectId: options.gcsProjectId,
                     gcsKeyFilename: options.gcsKeyFilename,
-                    gcsCachePrefix: options.gcsCachePrefix,
                 }),
                 port: parsePort(options.port),
                 debug: parseDebug(options.debug),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ function parseCacheStrategy(
         gcsCachePrefix: string;
         gcsProjectId: string;
         gcsKeyFilename: string;
+        gcsApiEndpoint: string;
     },
 ) {
     // command-line option
@@ -45,6 +46,7 @@ function parseCacheStrategy(
             projectId: options.gcsProjectId,
             keyFilename: options.gcsKeyFilename,
             prefix: options.gcsCachePrefix,
+            apiEndpoint: options.gcsApiEndpoint,
         });
 
     // command-line is not specified -> try to read from env
@@ -72,9 +74,10 @@ function parseCacheStrategy(
     if (cacheEnv === 'gcs')
         return caches.gcsCache({
             bucket: process.env.CHIITILER_GCS_CACHE_BUCKET ?? '',
-            prefix: process.env.CHIITILER_GCS_CACHE_PREFIX ?? '',
-            projectId: process.env.CHIITILER_GCS_PROJECT_ID ?? '',
-            keyFilename: process.env.CHIITILER_GCS_KEY_FILENAME ?? '',
+            prefix: process.env.CHIITILER_GCS_CACHE_PREFIX,
+            projectId: process.env.CHIITILER_GCS_PROJECT_ID,
+            keyFilename: process.env.CHIITILER_GCS_KEY_FILENAME,
+            apiEndpoint: process.env.CHIITILER_GCS_API_ENDPOINT,
         });
 
     // undefined or invalid
@@ -165,6 +168,11 @@ export function createProgram() {
             'gcs cache prefix',
             '',
         )
+        .option(
+            '-gcse --gcs-api-endpoint <api-endpoint>',
+            'gcs api endpoint',
+            '',
+        )
         .option('-p --port <port>', 'port number')
         .option('-r --stream', 'stream mode')
         .option('-D --debug', 'debug mode')
@@ -184,6 +192,7 @@ export function createProgram() {
                     gcsCachePrefix: options.gcsCachePrefix,
                     gcsProjectId: options.gcsProjectId,
                     gcsKeyFilename: options.gcsKeyFilename,
+                    gcsApiEndpoint: options.gcsApiEndpoint,
                 }),
                 port: parsePort(options.port),
                 debug: parseDebug(options.debug),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ function parseCacheStrategy(
         gcsCacheBucket: string;
         gcsProjectId: string;
         gcsKeyFilename: string;
+        gcsCachePrefix: string;
     },
 ) {
     // command-line option
@@ -43,6 +44,7 @@ function parseCacheStrategy(
             bucket: options.gcsCacheBucket,
             projectId: options.gcsProjectId,
             keyFilename: options.gcsKeyFilename,
+            prefix: options.gcsCachePrefix,
         });
 
     // command-line is not specified -> try to read from env
@@ -72,6 +74,7 @@ function parseCacheStrategy(
             bucket: process.env.CHIITILER_GCS_BUCKET ?? '',
             projectId: process.env.CHIITILER_GCS_PROJECT_ID ?? '',
             keyFilename: process.env.CHIITILER_GCS_KEY_FILENAME ?? '',
+            prefix: process.env.CHIITILER_GCS_PREFIX ?? '',
         });
 
     // undefined or invalid
@@ -157,6 +160,11 @@ export function createProgram() {
             'gcs key filename',
             '',
         )
+        .option(
+            '-gcsp --gcs-cache-prefix <prefix>',
+            'gcs cache prefix',
+            '',
+        )
         .option('-p --port <port>', 'port number')
         .option('-r --stream', 'stream mode')
         .option('-D --debug', 'debug mode')
@@ -175,6 +183,7 @@ export function createProgram() {
                     gcsCacheBucket: options.gcsCacheBucket,
                     gcsProjectId: options.gcsProjectId,
                     gcsKeyFilename: options.gcsKeyFilename,
+                    gcsCachePrefix: options.gcsCachePrefix,
                 }),
                 port: parsePort(options.port),
                 debug: parseDebug(options.debug),

--- a/src/gcs.test.ts
+++ b/src/gcs.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { Storage } from '@google-cloud/storage';
+
+import { getStorageClient } from './gcs.js';
+
+describe('getStorageClient', () => {
+    it('getStorageClient', async () => {
+        const client1 = getStorageClient({});
+        expect(client1).toBeInstanceOf(Storage);
+        const client2 = getStorageClient({});
+        expect(client2).toBe(client1); // singleton
+        const client3 = getStorageClient({ projectId: 'test-project' });
+        expect(client3).toBe(client1); // even when different options...
+    });
+});

--- a/src/gcs.ts
+++ b/src/gcs.ts
@@ -1,0 +1,22 @@
+import { Storage, type StorageOptions } from '@google-cloud/storage';
+
+let storageClient: Storage; // singleton
+const getStorageClient = function ({
+    projectId,
+    keyFilename,
+}: {
+    projectId?: string;
+    keyFilename?: string;
+}) {
+    if (storageClient !== undefined) return storageClient;
+
+    const storageOptions: StorageOptions = {
+        projectId,
+        keyFilename,
+    };
+
+    storageClient = new Storage(storageOptions);
+    return storageClient;
+};
+
+export { getStorageClient };

--- a/src/gcs.ts
+++ b/src/gcs.ts
@@ -13,6 +13,7 @@ const getStorageClient = function ({
     const storageOptions: StorageOptions = {
         projectId,
         keyFilename,
+        apiEndpoint: process.env.STORAGE_EMULATOR_HOST,
     };
 
     storageClient = new Storage(storageOptions);

--- a/src/gcs.ts
+++ b/src/gcs.ts
@@ -4,16 +4,18 @@ let storageClient: Storage; // singleton
 const getStorageClient = function ({
     projectId,
     keyFilename,
+    apiEndpoint
 }: {
     projectId?: string;
     keyFilename?: string;
+    apiEndpoint?: string;
 }) {
     if (storageClient !== undefined) return storageClient;
 
     const storageOptions: StorageOptions = {
         projectId,
         keyFilename,
-        apiEndpoint: process.env.STORAGE_EMULATOR_HOST,
+        apiEndpoint
     };
 
     storageClient = new Storage(storageOptions);

--- a/src/source/gcs.ts
+++ b/src/source/gcs.ts
@@ -1,0 +1,21 @@
+import { getStorageClient } from '../gcs.js';
+
+async function getGCSSource(uri: string) {
+    const storageClient = getStorageClient({
+        projectId: process.env.CHIITILER_GCS_PROJECT_ID,
+        keyFilename: process.env.CHIITILER_GCS_KEY_FILENAME,
+    });
+    const bucket = uri.replace('gs://', '').split('/')[0];
+    const path = uri.replace(`gs://${bucket}/`, '');
+
+    try {
+        const file = storageClient.bucket(bucket).file(path);
+        const [buffer] = await file.download();
+        return buffer;
+    } catch (e: any) {
+        if (e.code !== 404) console.log(e);
+        return null;
+    }
+}
+
+export { getGCSSource };

--- a/src/source/gcs.ts
+++ b/src/source/gcs.ts
@@ -4,6 +4,7 @@ async function getGCSSource(uri: string) {
     const storageClient = getStorageClient({
         projectId: process.env.CHIITILER_GCS_PROJECT_ID,
         keyFilename: process.env.CHIITILER_GCS_KEY_FILENAME,
+        apiEndpoint: process.env.CHIITILER_GCS_API_ENDPOINT,
     });
     const bucket = uri.replace('gs://', '').split('/')[0];
     const path = uri.replace(`gs://${bucket}/`, '');

--- a/src/source/index.ts
+++ b/src/source/index.ts
@@ -3,6 +3,7 @@ import { getHttpSource } from './http.js';
 import { getPmtilesSource } from './pmtiles.js';
 import { getMbtilesSource } from './mbtiles.js';
 import { getS3Source } from './s3.js';
+import { getGCSSource } from './gcs.js';
 import { getCogSource } from './cog.js';
 import { Cache, noneCache } from '../cache/index.js';
 
@@ -22,6 +23,7 @@ async function getSource(
         data = await getHttpSource(uri, cache);
     else if (uri.startsWith('file://')) data = await getFilesystemSource(uri);
     else if (uri.startsWith('s3://')) data = await getS3Source(uri);
+    else if (uri.startsWith('gs://')) data = await getGCSSource(uri);
     else if (uri.startsWith('mbtiles://')) data = await getMbtilesSource(uri);
     else if (uri.startsWith('pmtiles://'))
         data = await getPmtilesSource(uri, cache);


### PR DESCRIPTION
Thank you for developing this great application! It seems useful for PLATEAU VIEW, but GCS support is missing. So, I added GCS support.

Tested on my GCS and it works:

```
CHIITILER_CACHE_METHOD=gcs CHIITILER_GCS_CACHE_BUCKET=plateau-dev-app-tile-cache npm run dev
```

`http://localhost:3000/tiles/11/1818/805.png?url=http://localhost:58671/darkStyle.json` ->

![image](https://github.com/user-attachments/assets/38fe82c6-1685-4e44-84d1-41c7503b8978)
