### PR TITLE
feat: single-flight deduplication for source downloads

### DIFF
--- a/src/source/index.test.ts
+++ b/src/source/index.test.ts
@@ -40,6 +40,23 @@ describe('getSource', () => {
         expect(data).toBeNull();
     });
 
+    it('single-flight: concurrent requests for the same uri share one fetch', async () => {
+        const uri = 'https://demotiles.maplibre.org/style.json';
+        const fetchSpy = vi.spyOn(globalThis, 'fetch');
+        const before = fetchSpy.mock.calls.length;
+        const [a, b, c] = await Promise.all([
+            getSource(uri),
+            getSource(uri),
+            getSource(uri),
+        ]);
+        const after = fetchSpy.mock.calls.length;
+        expect(a).not.toBeNull();
+        expect(b).not.toBeNull();
+        expect(c).not.toBeNull();
+        expect(after - before).toBe(1);
+        fetchSpy.mockRestore();
+    });
+
     /**
     it('s3://', async () => {
         const uri = 's3://chiitiler/tiles/0/0/0.pbf';

--- a/src/source/index.ts
+++ b/src/source/index.ts
@@ -7,8 +7,27 @@ import { getGCSSource } from './gcs.js';
 import { getCogSource } from './cog.js';
 import { Cache, noneCache } from '../cache/index.js';
 
+async function fetchSource(
+    uri: string,
+    cache: Cache,
+): Promise<Buffer | null> {
+    if (uri.startsWith('http://') || uri.startsWith('https://'))
+        return getHttpSource(uri, cache);
+    if (uri.startsWith('file://')) return getFilesystemSource(uri);
+    if (uri.startsWith('s3://')) return getS3Source(uri);
+    if (uri.startsWith('gs://')) return getGCSSource(uri);
+    if (uri.startsWith('mbtiles://')) return getMbtilesSource(uri);
+    if (uri.startsWith('pmtiles://')) return getPmtilesSource(uri, cache);
+    if (uri.startsWith('cog://')) return getCogSource(uri);
+    return null;
+}
+
+const inFlight = new Map<string, Promise<Buffer | null>>();
+
 /**
- * retrieve sources from the uri
+ * retrieve sources from the uri.
+ * Concurrent requests for the same uri share a single in-flight fetch
+ * (single-flight) to avoid duplicate downloads.
  * @param uri
  * @param cache {Cache} - Cache Strategy. Affect only for http(s) sources.
  * @returns
@@ -17,20 +36,14 @@ async function getSource(
     uri: string,
     cache: Cache = noneCache(),
 ): Promise<Buffer | null> {
-    let data: Buffer | null = null;
+    const existing = inFlight.get(uri);
+    if (existing !== undefined) return existing;
 
-    if (uri.startsWith('http://') || uri.startsWith('https://'))
-        data = await getHttpSource(uri, cache);
-    else if (uri.startsWith('file://')) data = await getFilesystemSource(uri);
-    else if (uri.startsWith('s3://')) data = await getS3Source(uri);
-    else if (uri.startsWith('gs://')) data = await getGCSSource(uri);
-    else if (uri.startsWith('mbtiles://')) data = await getMbtilesSource(uri);
-    else if (uri.startsWith('pmtiles://'))
-        data = await getPmtilesSource(uri, cache);
-    else if (uri.startsWith('cog://')) data = await getCogSource(uri);
-    else return null;
-
-    return data;
+    const promise = fetchSource(uri, cache).finally(() => {
+        inFlight.delete(uri);
+    });
+    inFlight.set(uri, promise);
+    return promise;
 }
 
 export { getSource };


### PR DESCRIPTION
## Summary
- 同じ URI への並列リクエストを 1 つの fetch にまとめる single-flight を `getSource` に実装
- HTTP/S3/GCS/pmtiles/mbtiles/COG/file すべてのソース種別を一律で重複排除
- 多数のタイルを同時レンダリングする際の重複ダウンロードを削減

## Why
現状は同一 URI のタイルやスタイル等に並列リクエストが走ると、それぞれが別々にネットワークフェッチを発行していた。レンダリングで同じリソースが同時に要求されるケースでは不要な帯域/API 呼び出しが発生する。

## Implementation
`src/source/index.ts` で URI → 進行中 Promise の Map を保持し、既存の Promise があればそれを返す。Promise の settle 後に Map から削除する。キャッシュ層とは独立した in-memory な in-flight 排他。

## Test plan
- [x] `src/source/index.test.ts` に 3 並列リクエストで fetch が 1 回だけ呼ばれることを確認するテストを追加
- [x] `vitest run src/source/index.test.ts` — 7/7 passed
- [x] `tsc --noEmit` — エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)