### PR TITLE
chore: swap MinIO for RustFS in local docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Chiitiler caches *source assets* (vector tiles, glyphs, sprites) — not final r
 ## Deployment
 
 - **Docker** — `ghcr.io/kanahiro/chiitiler:latest` (entrypoint: `tile-server`)
-- **Docker Compose** — see [`docker-compose.yml`](./docker-compose.yml) (includes MinIO + fake-gcs-server for local testing)
+- **Docker Compose** — see [`docker-compose.yml`](./docker-compose.yml) (includes RustFS + fake-gcs-server for local testing)
 - **AWS Lambda** — ready-to-deploy CDK app in [`cdk/`](./cdk)
 
 ## Develop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,40 +17,37 @@ services:
             - CHIITILER_CACHE_METHOD=s3
             - CHIITILER_S3CACHE_BUCKET=chiitiler
             - CHIITILER_S3_REGION=ap-northeast-1
-            - CHIITILER_S3_ENDPOINT=http://minio:9000
+            - CHIITILER_S3_ENDPOINT=http://rustfs:9000
             - CHIITILER_S3_FORCE_PATH_STYLE=true
             - CHIITILER_PROCESSES=0
             - CHIITILER_STREAM_MODE=true
-            - AWS_ACCESS_KEY_ID=minioadmin
-            - AWS_SECRET_ACCESS_KEY=minioadmin
+            - AWS_ACCESS_KEY_ID=rustfsadmin
+            - AWS_SECRET_ACCESS_KEY=rustfsadmin
             - CHIITILER_GCS_API_ENDPOINT=http://fake-gcs-server:4443
             - CHIITILER_GCS_CACHE_BUCKET=tiles
-    minio:
-        image: minio/minio:latest
+    rustfs:
+        image: rustfs/rustfs:latest
         ports:
             - 9000:9000 # S3-compatible API
             - 9001:9001 # Web Console
         environment:
-            - MINIO_ROOT_USER=minioadmin
-            - MINIO_ROOT_PASSWORD=minioadmin
-        command: server --console-address ":9001" /data
-        healthcheck:
-            test:
-                ['CMD', 'curl', '-f', 'http://localhost:9000/minio/health/live']
-            interval: 1s
-            timeout: 20s
-            retries: 3
+            - RUSTFS_ACCESS_KEY=rustfsadmin
+            - RUSTFS_SECRET_KEY=rustfsadmin
     createbuckets:
-        image: minio/mc:RELEASE.2022-12-24T15-21-38Z
+        image: amazon/aws-cli:latest
         depends_on:
-            - minio
+            - rustfs
         entrypoint: >
             /bin/sh -c "
-            mc alias set myminio http://minio:9000 minioadmin minioadmin;
-            mc mb myminio/chiitiler;
-            mc mb myminio/tiles;
-            mc cp initdata/tiles/* myminio/tiles --recursive;
+            until aws --endpoint-url http://rustfs:9000 s3 ls > /dev/null 2>&1; do sleep 1; done;
+            aws --endpoint-url http://rustfs:9000 s3 mb s3://chiitiler;
+            aws --endpoint-url http://rustfs:9000 s3 mb s3://tiles;
+            aws --endpoint-url http://rustfs:9000 s3 cp /initdata/tiles/ s3://tiles/ --recursive;
             "
+        environment:
+            - AWS_ACCESS_KEY_ID=rustfsadmin
+            - AWS_SECRET_ACCESS_KEY=rustfsadmin
+            - AWS_DEFAULT_REGION=ap-northeast-1
         volumes:
             - ./localdata:/initdata
     fake-gcs-server:


### PR DESCRIPTION
## Summary
- MinIO is in maintenance mode, so swap the local dev/test stack to [RustFS](https://github.com/rustfs/rustfs), a 100% S3-compatible drop-in replacement.
- Replace the `minio/mc` bucket bootstrap with `amazon/aws-cli` plus a readiness wait loop, so the bootstrap is decoupled from any particular S3 server.
- Update README wording (MinIO → RustFS).

## What changed
- `docker-compose.yml`
  - `minio` service → `rustfs` service (`rustfs/rustfs:latest`, creds via `RUSTFS_ACCESS_KEY` / `RUSTFS_SECRET_KEY`).
  - Ports 9000/9001 preserved for API/console parity.
  - `createbuckets` now uses `amazon/aws-cli:latest`, waits for the endpoint, creates the `chiitiler` + `tiles` buckets, and uploads `initdata/tiles/` via `aws s3 cp --recursive`.
  - App env: `CHIITILER_S3_ENDPOINT` → `http://rustfs:9000`, `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` → `rustfsadmin`.
- `README.md`: deployment note now mentions RustFS instead of MinIO.

## Test plan
Verified locally with `docker compose up`:
- [x] `rustfs` container starts and initializes `/data`.
- [x] `createbuckets` creates both buckets and uploads all tile fixtures (exit 0).
- [x] `aws-cli` lists `chiitiler` + `tiles` buckets against `http://rustfs:9000`.
- [x] `app` starts with `cache method: s3` pointing at RustFS.
- [x] `GET /tiles/0/0/0.png?url=file://localdata/style.json` → HTTP 200, valid 512×512 PNG.
- [x] OSM raster cache is written to `s3://chiitiler/` after the render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)