### PR TITLE
fix: return 500 with text/plain on render failure

### DIFF
--- a/src/server/routes/camera.ts
+++ b/src/server/routes/camera.ts
@@ -92,7 +92,9 @@ function createCameraRouter(options: { cache: Cache }) {
 				return c.body(buf as Uint8Array<ArrayBuffer>);
 			} catch (e) {
 				console.error(`render error: ${e}`);
-				return c.body('failed to render static image', 400);
+				// c.text overrides the image/* Content-Type set above; a render
+				// failure is a server-side error so respond 500, not 400.
+				return c.text('failed to render static image', 500);
 			}
 		})
 		.post('/:zoom/:lat/:lon/:bearing/:pitch/:dimensions_ext', async (c) => {
@@ -155,7 +157,9 @@ function createCameraRouter(options: { cache: Cache }) {
 				return c.body(buf as Uint8Array<ArrayBuffer>);
 			} catch (e) {
 				console.error(`render error: ${e}`);
-				return c.body('failed to render static image', 400);
+				// c.text overrides the image/* Content-Type set above; a render
+				// failure is a server-side error so respond 500, not 400.
+				return c.text('failed to render static image', 500);
 			}
 		});
 	return camera;

--- a/src/server/routes/clip.ts
+++ b/src/server/routes/clip.ts
@@ -38,7 +38,9 @@ function createClipRouter(options: { cache: Cache }) {
 				return c.body(buf as Uint8Array<ArrayBuffer>);
 			} catch (e) {
 				console.error(`render error: ${e}`);
-				return c.body('failed to render tile', 400);
+				// c.text overrides the image/* Content-Type set above; a render
+				// failure is a server-side error so respond 500, not 400.
+				return c.text('failed to render tile', 500);
 			}
 		})
 		.post('/:filename_ext', async (c) => {
@@ -78,7 +80,9 @@ function createClipRouter(options: { cache: Cache }) {
 				return c.body(buf as Uint8Array<ArrayBuffer>);
 			} catch (e) {
 				console.error(`render error: ${e}`);
-				return c.body('failed to render tile', 400);
+				// c.text overrides the image/* Content-Type set above; a render
+				// failure is a server-side error so respond 500, not 400.
+				return c.text('failed to render tile', 500);
 			}
 		});
 	return clip;

--- a/src/server/routes/tiles.ts
+++ b/src/server/routes/tiles.ts
@@ -48,7 +48,9 @@ function createTilesRouter(options: { cache: Cache }) {
 				return c.body(buf as Uint8Array<ArrayBuffer>);
 			} catch (e) {
 				console.error(`render error: ${e}`);
-				return c.body('failed to render tile', 400);
+				// c.text overrides the image/* Content-Type set above; a render
+				// failure is a server-side error so respond 500, not 400.
+				return c.text('failed to render tile', 500);
 			}
 		})
 		.post('/:z/:x/:y_ext', async (c) => {
@@ -91,7 +93,9 @@ function createTilesRouter(options: { cache: Cache }) {
 				return c.body(buf as Uint8Array<ArrayBuffer>);
 			} catch (e) {
 				console.error(`render error: ${e}`);
-				return c.body('failed to render tile', 400);
+				// c.text overrides the image/* Content-Type set above; a render
+				// failure is a server-side error so respond 500, not 400.
+				return c.text('failed to render tile', 500);
 			}
 		});
 	return tiles;

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -80,6 +80,17 @@ describe('intergration test', () => {
         expect(pngsize.width).toBe(512);
         expect(pngsize.height).toBe(512);
     });
+    test('GET /tiles render failure -> 500 text/plain', async () => {
+        // unresolvable style url: render throws, must not be reported as a
+        // client error nor mislabeled with the image content-type set earlier
+        const res = await fetch(
+            'http://localhost:3000/tiles/0/0/0.png?url=file://localdata/nonexistent.json',
+        );
+        expect(res.status).toBe(500);
+        expect(res.headers.get('content-type')).toMatch(/^text\/plain/);
+        expect(await res.text()).toBe('failed to render tile');
+    });
+
     test('POST /tiles invalid', async () => {
         const res = await fetch('http://localhost:3000/tiles/0/0/0.png', {
             method: 'POST',
@@ -154,6 +165,15 @@ describe('intergration test', () => {
         const webpsize = sizeof(webp);
         expect(webpsize.width).toBe(512);
         expect(webpsize.height).toBe(451);
+    });
+
+    test('GET /bbox render failure -> 500 text/plain', async () => {
+        const res = await fetch(
+            'http://localhost:3000/clip.png?bbox=100,30,150,60&url=file://localdata/nonexistent.json',
+        );
+        expect(res.status).toBe(500);
+        expect(res.headers.get('content-type')).toMatch(/^text\/plain/);
+        expect(await res.text()).toBe('failed to render tile');
     });
 
     test('POST /bbox valid', async () => {
@@ -249,6 +269,15 @@ describe('intergration test', () => {
         const webpsize = sizeof(webp);
         expect(webpsize.width).toBe(512);
         expect(webpsize.height).toBe(512);
+    });
+
+    test('GET /static render failure -> 500 text/plain', async () => {
+        const res = await fetch(
+            'http://localhost:3000/camera/10/56.7/123.4/0/0/1024x1024.png?url=file://localdata/nonexistent.json',
+        );
+        expect(res.status).toBe(500);
+        expect(res.headers.get('content-type')).toMatch(/^text\/plain/);
+        expect(await res.text()).toBe('failed to render static image');
     });
 
     test('POST /static valid', async () => {


### PR DESCRIPTION
## 概要

レンダリング失敗時のレスポンスを修正。従来は **400** を返し、かつ try ブロック直前で設定した `Content-Type: image/*` がそのまま残った状態でテキストボディを返していたため、クライアントやCDNが「画像として返ってきたテキスト」を受け取って誤動作する原因になっていた。

## 変更

- レンダリング失敗はサーバー側エラーなので **400 → 500**
- `c.body(...)` → `c.text(...)` に変更。`c.text` は Content-Type を `text/plain; charset=UTF-8` に明示的に上書きするため、残留していた `image/*` を正しいテキスト型に置き換える
- 対象: `tiles` / `clip` / `camera` の GET・POST 計6ハンドラ
- バリデーション失敗（不正な bbox・format・stylejson など）は引き続き 400 のまま

## テスト

integration test に各ルート(GET)のレンダリング失敗ケースを追加し、`500` + `text/plain` + 正しいエラーメッセージを検証。サーバー起動の上で全14テストpass確認済み（修正前は 400 / image/png で fail する）。