### PR TITLE
refactor(docker): slim runtime image to minimal shared libs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,44 @@
-FROM node:24-bookworm-slim as builder
+FROM node:24-bookworm-slim AS builder
 
 WORKDIR /app/
 COPY . /app/
 RUN npm install
 RUN npm run build
-# /app/build/main.cjs
+# -> /app/build/main.cjs
 
-FROM ubuntu:noble as runtime
+FROM ubuntu:noble AS runtime
 
-# Install dependencies
+# Runtime shared libraries required by @maplibre/maplibre-gl-native (mbgl.node).
+# This is the minimal set derived from `ldd .../mbgl.node` (runtime .so packages only,
+# no -dev headers or toolchain), plus xvfb for the headless GL context.
+# Why ubuntu:noble and not bookworm-slim: the prebuilt mbgl.node links GLIBC_2.38 /
+# GLIBCXX_3.4.32, which Debian bookworm (glibc 2.36) does not provide.
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
   xvfb \
-  libcurl4-openssl-dev \
-  libglfw3-dev \
-  libuv1-dev \
-  libjpeg-turbo8-dev \
-  libpng-dev \
-  libwebp-dev
+  libopengl0 \
+  libglx0 \
+  libcurl4t64 \
+  libjpeg-turbo8 \
+  libuv1t64 \
+  libx11-6 \
+  libxext6 \
+  libwebp7 \
+  libicu74 \
+  libpng16-16t64 \
+  && rm -rf /var/lib/apt/lists/*
 
 # Lambda WebAdapter
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
 ENV PORT=3000
 ENV READINESS_CHECK_PATH=/health
 
-# Copy Node.js executable from node:24-bookworm-slim
+# Node.js runtime (taken from bookworm-slim; noble's newer glibc runs it fine).
 COPY --from=node:24-bookworm-slim /usr/local/bin /usr/local/bin
 COPY --from=node:24-bookworm-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
 
-# Copy /app/dist from builder
+# Install production dependencies on the runtime image so native modules
+# (mbgl.node, sharp) get noble-appropriate prebuilds.
 WORKDIR /app/
 COPY --from=builder /app/build /app/build
 COPY --from=builder /app/package.json /app/package.json


### PR DESCRIPTION
## 概要
ランタイムイメージを軽量化。`-dev` パッケージを、実行に必要な共有ライブラリ（`.so`）の最小集合に置き換えました。

集合は `ldd node_modules/@maplibre/maplibre-gl-native/lib/*/mbgl.node` から機械的に導出しています。

## 変更点
- `-dev` パッケージ群 → ランタイム `.so` パッケージのみに置き換え
- **`libglfw3` を削除**（`ldd` に現れず、mbgl.node@6.4.1 は直接リンクしていない）
- これまで `-dev` の推移依存で暗黙に入っていた必須ライブラリを明示追加: `libopengl0` / `libglx0` / `libx11-6` / `libxext6` / `libicu74`
- noble の t64 移行に合わせ `libuv1` → `libuv1t64`、`libpng16-16` → `libpng16-16t64`
- `apt-get update && install` を1レイヤに統合し `--no-install-recommends` + `rm -rf /var/lib/apt/lists/*`

## ランタイム base は ubuntu:noble のまま維持
prebuilt の `mbgl.node` が **`GLIBC_2.38` / `GLIBCXX_3.4.32`** を要求するため、bookworm（glibc 2.36）では動作しません。これが noble を使う理由そのものです。

## 検証（実機 Docker ビルド + レンダリング）
- ✅ ビルド成功
- ✅ `/tiles/0/0/0.png` → 512×512 PNG 描画成功（Xvfb 上で GL コンテキスト動作）
- ✅ `.webp` 出力も成功（libwebp 経路）
- ✅ ライブラリのロード失敗ログなし
- 📉 **イメージサイズ: 約 1.2GB → 892MB（約 26% / 308MB 減）**