### PR TITLE
fix: remove gray halo edges on transparent tiles (premultiplied alpha)

### DIFF
--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -83,6 +83,10 @@ async function getRenderedTile({
 				width: 512,
 				height: 512,
 				channels: 4,
+				// maplibre-native returns premultiplied alpha; tell sharp so it
+				// unpremultiplies to straight alpha, otherwise antialiased edges
+				// (e.g. white text-halo) come out gray on transparent backgrounds.
+				premultiplied: true,
 			},
 		}).resize(256, 256);
 	} else if (margin === 0) {
@@ -91,6 +95,7 @@ async function getRenderedTile({
 				width: tileSize,
 				height: tileSize,
 				channels: 4,
+				premultiplied: true,
 			},
 		});
 	} else {
@@ -99,6 +104,7 @@ async function getRenderedTile({
 				width: tileSize + margin,
 				height: tileSize + margin,
 				channels: 4,
+				premultiplied: true,
 			},
 		})
 			.extract({
@@ -192,6 +198,8 @@ async function getRenderedClip({
 			width,
 			height,
 			channels: 4,
+			// see getRenderedTile: maplibre-native returns premultiplied alpha
+			premultiplied: true,
 		},
 	});
 
@@ -241,6 +249,8 @@ async function getRenderedCamera(options: GetRenderedCameraOptions) {
 			width: options.width,
 			height: options.height,
 			channels: 4,
+			// see getRenderedTile: maplibre-native returns premultiplied alpha
+			premultiplied: true,
 		},
 	});
 


### PR DESCRIPTION
before 
<img width="512" height="512" alt="12904-before" src="https://github.com/user-attachments/assets/dbf9583d-1b1d-4c72-9589-c93a666bc968" />

after
<img width="512" height="512" alt="12904" src="https://github.com/user-attachments/assets/0f2c95ba-a87b-47a1-b87b-1a35c69750d6" />


## 概要

透明背景・background なしのタイルで、白い text-halo などのアンチエイリアス縁が**グレーのジャギー**として出力される問題を修正する。

## 原因

`maplibre-native` はレンダリング結果を **premultiplied alpha** の生 RGBA バッファとして返すが、`sharp` は raw 入力を **straight alpha** と仮定する。premult のまま PNG/WebP に書き出されるため、α が中間値のエッジ（白 halo など）がグレー化していた。不透明背景では下地と混ざって目立たず、透明時のみ顕在化する。

## 修正

`sharp` の raw 入力に `premultiplied: true` を指定し、straight alpha へ展開させる。これは resize / extract より前に行われるため、エッジが二重に汚れることもない。`getRenderedTile`（3分岐すべて）/ `getRenderedClip` / `getRenderedCamera` の計5箇所に適用。

> 注: 作業指示では `.unpremultiply()` メソッドを想定していたが、当リポジトリの `sharp` 0.34.5 には当該メソッドが存在せず（tsc で全箇所エラー）、同等の機能を持つ `raw.premultiplied` フラグを用いた。

## 検証（実機）

非最大色 `#3366cc` の円を透明背景でレンダリングし、エッジ色を α 別に計測。premult / straight を区別できる唯一のケース。

| alpha 帯 | 出力エッジ RGB | 真の色 |
|---|---|---|
| ~0–40 | (49,101,205) | (51,102,204) |
| ~40–240 | (51,102,203) | (51,102,204) |

全 α 帯で真の色に一致 → maplibre 出力が premultiplied であること、および本修正で正しく straight へ復元されることを確認。仮に元々 straight なら α 低下に伴いエッジが白飛びするが、そうならない。

確認した経路:
- tiles png（256-resize / margin / margin=0 の3分岐）, webp, jpeg → 200・straight エッジ
- clip（static）png → 200・straight エッジ
- camera png → 200・straight エッジ
- **不透明背景のデグレなし**: 赤背景の円中心 = `(51,102,204,255)` で色ずれなし

## ロールバック

5箇所の `premultiplied: true` 行を削除するだけで元の挙動に戻る。