### PR TITLE
feat: send identifying User-Agent on outbound HTTP requests by default

### DIFF
--- a/.github/workflows/test:integration.yml
+++ b/.github/workflows/test:integration.yml
@@ -23,7 +23,13 @@ jobs:
                   node-version: "24"
             - name: start server
               run: docker compose up -d
-            - name: run test
+            - name: install dependencies
+              run: npm install
+            # the app container installs dependencies at startup, so listening
+            # begins well after `docker compose up -d` returns
+            - name: wait for server
               run: |
-                  npm install
-                  npm run test:integration
+                  timeout 300 bash -c 'until curl -sf http://localhost:3000/health > /dev/null; do sleep 2; done' \
+                    || { docker compose logs app; exit 1; }
+            - name: run test
+              run: npm run test:integration

--- a/.github/workflows/test:integration.yml
+++ b/.github/workflows/test:integration.yml
@@ -7,6 +7,10 @@ on:
         paths:
             - "src/**"
             - "tests/**"
+            - "Dockerfile"
+            - "docker-compose.yml"
+            - "package.json"
+            - "package-lock.json"
             - ".github/workflows/test:integration.yml"
     workflow_dispatch:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,9 @@ RUN node -e "const fs = require('node:fs'); const names = ['@maplibre/maplibre-g
   && mkdir -p node_modules/@maplibre \
   && mv /tmp/maplibre-gl-native node_modules/@maplibre/maplibre-gl-native
 
-FROM ubuntu:noble AS runtime
-
 # mbgl.node requires GLIBC_2.38 and GLIBCXX_3.4.32. These `ldd`-derived
 # libraries and Xvfb provide its headless GL runtime on Ubuntu Noble.
+FROM ubuntu:noble AS gl-base
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
   xvfb \
@@ -39,6 +38,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libicu74 \
   libpng16-16t64 \
   && rm -rf /var/lib/apt/lists/*
+
+# Dev image for docker-compose: full Node toolchain (npm included) with all
+# dependencies installed at build time, so the container is ready at startup.
+# src is provided by a bind mount.
+FROM gl-base AS dev
+
+COPY --from=node:24-bookworm-slim /usr/local/bin /usr/local/bin
+COPY --from=node:24-bookworm-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
+
+WORKDIR /app
+COPY package.json package-lock.json tsconfig.json ./
+RUN npm ci --no-audit --no-fund
+
+FROM gl-base AS runtime
 
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
 ENV PORT=3000

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ const png = await getRenderedTileBuffer({
 
 Available renderers: `getRenderedTileBuffer`, `getRenderedClipBuffer`, `getRenderedCameraBuffer`, and their `*Stream` variants (`Sharp` instances for further piping).
 
+Outbound HTTP requests send a `User-Agent` identifying chiitiler by default; override it with `setUserAgent('my-app/1.0')` or the `CHIITILER_USER_AGENT` environment variable.
+
 ## Configuration
 
 All options can be set via CLI flag or environment variable.
@@ -117,6 +119,7 @@ All options can be set via CLI flag or environment variable.
 | --- | --- | --- |
 | `--port <n>` | `CHIITILER_PORT` | `3000` |
 | `--debug` | `CHIITILER_DEBUG` | `false` |
+| `--user-agent <ua>` | `CHIITILER_USER_AGENT` | `chiitiler (+https://github.com/Kanahiro/chiitiler)` |
 | — | `CHIITILER_PROCESSES` | `1` (set `0` for all CPUs) |
 
 ### Cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
     app:
-        build: ./
+        build:
+            context: ./
+            target: dev
         volumes:
             - ./src:/app/src
             - ./.cache:/app/.cache
@@ -11,7 +13,6 @@ services:
         command:
             - -c
             - |
-                npm install
                 /usr/bin/xvfb-run -a npm run dev
         environment:
             - CHIITILER_CACHE_METHOD=s3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chiitiler",
-  "version": "1.21.3",
+  "version": "1.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chiitiler",
-      "version": "1.21.3",
+      "version": "1.22.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1032.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "chiitiler",
-  "version": "1.21.3",
+  "version": "1.22.0",
   "description": "Tiny map rendering server for MapLibre Style Spec",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { Command } from 'commander';
 
 import { initServer, type InitServerOptions } from './server/index.js';
 import * as caches from './cache/index.js';
+import { setUserAgent } from './source/userAgent.js';
 
 function parseCacheStrategy(
     method: 'none' | 'memory' | 'file' | 's3' | 'gcs',
@@ -162,8 +163,15 @@ export function createProgram() {
             '',
         )
         .option('-p, --port <port>', 'port number')
+        .option(
+            '--user-agent <user-agent>',
+            'User-Agent header for outbound HTTP requests',
+        )
         .option('-D, --debug', 'debug mode')
         .action((options) => {
+            // env fallback (CHIITILER_USER_AGENT) is handled in userAgent.ts
+            if (options.userAgent !== undefined) setUserAgent(options.userAgent);
+
             const serverOptions: InitServerOptions = {
                 cache: parseCacheStrategy(options.cache, {
                     cacheTtl: Number(options.cacheTtl),

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,3 +33,4 @@ export async function getRenderedTileBuffer(
 export { getRenderedTile as getRenderedTileStream };
 
 export * as ChiitilerCache from './cache/index.js';
+export { setUserAgent } from './source/userAgent.js';

--- a/src/source/http.test.ts
+++ b/src/source/http.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 
 import { getHttpSource } from './http.js';
+import { setUserAgent } from './userAgent.js';
 import { memoryCache } from '../cache/memory.js';
 
 function mockFetch(response: Response) {
@@ -46,6 +47,35 @@ describe('getHttpSource', () => {
         const data = await getHttpSource('https://example.com/missing.webp', cache);
 
         expect(data).toBeNull();
+    });
+
+    it('sends a default User-Agent header', async () => {
+        const fetchSpy = mockFetch(
+            new Response(new Uint8Array([1]), { status: 200 }),
+        );
+
+        await getHttpSource('https://example.com/tile.webp');
+
+        const [, init] = fetchSpy.mock.calls[0];
+        expect(new Headers(init?.headers).get('User-Agent')).toMatch(
+            /^chiitiler/,
+        );
+    });
+
+    it('sends a user-specified User-Agent header', async () => {
+        const fetchSpy = mockFetch(
+            new Response(new Uint8Array([1]), { status: 200 }),
+        );
+        setUserAgent('my-app/1.0');
+
+        try {
+            await getHttpSource('https://example.com/tile.webp');
+        } finally {
+            setUserAgent(undefined);
+        }
+
+        const [, init] = fetchSpy.mock.calls[0];
+        expect(new Headers(init?.headers).get('User-Agent')).toBe('my-app/1.0');
     });
 
     it('returns and caches a non-empty body', async () => {

--- a/src/source/http.ts
+++ b/src/source/http.ts
@@ -2,6 +2,7 @@
 // for using native fetch in TypeScript
 
 import { type Cache, noneCache } from '../cache/index.js';
+import { getUserAgent } from './userAgent.js';
 
 async function getHttpSource(
     uri: string,
@@ -13,7 +14,9 @@ async function getHttpSource(
 
     // miss
     try {
-        const res = await fetch(uri);
+        const res = await fetch(uri, {
+            headers: { 'User-Agent': getUserAgent() },
+        });
         if (!res.ok) {
             console.log(`failed to fetch ${uri}`);
             return null;

--- a/src/source/pmtiles.ts
+++ b/src/source/pmtiles.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 
-import { PMTiles, Source, RangeResponse } from 'pmtiles';
+import { PMTiles, FetchSource, Source, RangeResponse } from 'pmtiles';
 import {
 	GetObjectCommand,
 	GetObjectCommandOutput,
@@ -10,6 +10,7 @@ import { LRUCache } from 'lru-cache';
 
 import { getS3Client } from '../s3.js';
 import { type Cache, noneCache } from '../cache/index.js';
+import { getUserAgent } from './userAgent.js';
 
 const pmtilesCache = new LRUCache<string, PMTiles>({
 	max: 50,
@@ -112,7 +113,11 @@ async function getPmtilesSource(
 		if (val !== undefined) return val; // hit
 
 		if (pmtiles === undefined) {
-			pmtiles = new PMTiles(pmtilesUri);
+			const fetchSource = new FetchSource(
+				pmtilesUri,
+				new Headers({ 'User-Agent': getUserAgent() }),
+			);
+			pmtiles = new PMTiles(fetchSource);
 			pmtilesCache.set(pmtilesUri, pmtiles);
 		}
 	} else if (pmtilesUri.startsWith('s3://')) {

--- a/src/source/userAgent.ts
+++ b/src/source/userAgent.ts
@@ -1,0 +1,24 @@
+// User-Agent for all outbound HTTP requests (http(s):// and pmtiles://http(s)://).
+// Some tile providers (e.g. OpenStreetMap) reject requests without an
+// identifying User-Agent, so we always send one.
+const DEFAULT_USER_AGENT = 'chiitiler (+https://github.com/Kanahiro/chiitiler)';
+
+let overrideUserAgent: string | undefined;
+
+/**
+ * Override the User-Agent sent with outbound HTTP requests.
+ * Takes precedence over the CHIITILER_USER_AGENT environment variable.
+ */
+function setUserAgent(userAgent: string | undefined) {
+    overrideUserAgent = userAgent;
+}
+
+function getUserAgent(): string {
+    return (
+        overrideUserAgent ??
+        process.env.CHIITILER_USER_AGENT ??
+        DEFAULT_USER_AGENT
+    );
+}
+
+export { getUserAgent, setUserAgent };


### PR DESCRIPTION
## Summary

chiitiler's outbound HTTP requests carried no identifying `User-Agent`, so providers that require one — e.g. OpenStreetMap's [Tile Usage Policy](https://operations.osmfoundation.org/policies/tiles/) — could block requests.

- Send `chiitiler (+https://github.com/Kanahiro/chiitiler)` by default on all outbound HTTP requests: `http(s)://` sources and `pmtiles://http(s)://` sources (via pmtiles `FetchSource` custom headers).
- User-configurable: `--user-agent` CLI flag, `CHIITILER_USER_AGENT` env var, and `setUserAgent()` export for library usage (precedence in that reverse order: setter > env > default).
- UA resolution lives in a single module `src/source/userAgent.ts` — a process-wide setting, so it is not threaded through the render pipeline.

Note: `cog://` sources (higuruma) do their own HTTP internally and are out of scope.

## Version

Minor bump to v1.22.0.

## Test plan

- Unit tests added in `src/source/http.test.ts` for default and user-specified UA (mocked fetch).
- `npm run check` and unit tests pass.