### PR TITLE
fix: don't override User-Agent by default (v1.22.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ const png = await getRenderedTileBuffer({
 
 Available renderers: `getRenderedTileBuffer`, `getRenderedClipBuffer`, `getRenderedCameraBuffer`, and their `*Stream` variants (`Sharp` instances for further piping).
 
-Outbound HTTP requests send a `User-Agent` identifying chiitiler by default; override it with `setUserAgent('my-app/1.0')` or the `CHIITILER_USER_AGENT` environment variable.
+chiitiler doesn't override the `User-Agent` on outbound HTTP requests by default, so the runtime's default is used (Node sends `node`). Some tile providers (e.g. OpenStreetMap) require an identifying User-Agent — set one with `setUserAgent('my-app/1.0')` or the `CHIITILER_USER_AGENT` environment variable.
 
 ## Configuration
 
@@ -119,7 +119,7 @@ All options can be set via CLI flag or environment variable.
 | --- | --- | --- |
 | `--port <n>` | `CHIITILER_PORT` | `3000` |
 | `--debug` | `CHIITILER_DEBUG` | `false` |
-| `--user-agent <ua>` | `CHIITILER_USER_AGENT` | `chiitiler (+https://github.com/Kanahiro/chiitiler)` |
+| `--user-agent <ua>` | `CHIITILER_USER_AGENT` | (none) |
 | — | `CHIITILER_PROCESSES` | `1` (set `0` for all CPUs) |
 
 ### Cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chiitiler",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chiitiler",
-      "version": "1.22.0",
+      "version": "1.22.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1032.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "chiitiler",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "description": "Tiny map rendering server for MapLibre Style Spec",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/source/http.test.ts
+++ b/src/source/http.test.ts
@@ -49,7 +49,7 @@ describe('getHttpSource', () => {
         expect(data).toBeNull();
     });
 
-    it('sends a default User-Agent header', async () => {
+    it('does not send a User-Agent header by default', async () => {
         const fetchSpy = mockFetch(
             new Response(new Uint8Array([1]), { status: 200 }),
         );
@@ -57,9 +57,7 @@ describe('getHttpSource', () => {
         await getHttpSource('https://example.com/tile.webp');
 
         const [, init] = fetchSpy.mock.calls[0];
-        expect(new Headers(init?.headers).get('User-Agent')).toMatch(
-            /^chiitiler/,
-        );
+        expect(new Headers(init?.headers).get('User-Agent')).toBeNull();
     });
 
     it('sends a user-specified User-Agent header', async () => {

--- a/src/source/http.ts
+++ b/src/source/http.ts
@@ -14,8 +14,9 @@ async function getHttpSource(
 
     // miss
     try {
+        const userAgent = getUserAgent();
         const res = await fetch(uri, {
-            headers: { 'User-Agent': getUserAgent() },
+            headers: userAgent ? { 'User-Agent': userAgent } : undefined,
         });
         if (!res.ok) {
             console.log(`failed to fetch ${uri}`);

--- a/src/source/pmtiles.ts
+++ b/src/source/pmtiles.ts
@@ -113,10 +113,10 @@ async function getPmtilesSource(
 		if (val !== undefined) return val; // hit
 
 		if (pmtiles === undefined) {
-			const fetchSource = new FetchSource(
-				pmtilesUri,
-				new Headers({ 'User-Agent': getUserAgent() }),
-			);
+			const userAgent = getUserAgent();
+			const headers = new Headers();
+			if (userAgent) headers.set('User-Agent', userAgent);
+			const fetchSource = new FetchSource(pmtilesUri, headers);
 			pmtiles = new PMTiles(fetchSource);
 			pmtilesCache.set(pmtilesUri, pmtiles);
 		}

--- a/src/source/userAgent.ts
+++ b/src/source/userAgent.ts
@@ -1,8 +1,7 @@
 // User-Agent for all outbound HTTP requests (http(s):// and pmtiles://http(s)://).
-// Some tile providers (e.g. OpenStreetMap) reject requests without an
-// identifying User-Agent, so we always send one.
-const DEFAULT_USER_AGENT = 'chiitiler (+https://github.com/Kanahiro/chiitiler)';
-
+// By default we don't override the User-Agent at all (the runtime's default is
+// used). Set one explicitly via --user-agent, CHIITILER_USER_AGENT, or
+// setUserAgent() — e.g. some tile providers (OpenStreetMap) require one.
 let overrideUserAgent: string | undefined;
 
 /**
@@ -13,12 +12,12 @@ function setUserAgent(userAgent: string | undefined) {
     overrideUserAgent = userAgent;
 }
 
-function getUserAgent(): string {
-    return (
-        overrideUserAgent ??
-        process.env.CHIITILER_USER_AGENT ??
-        DEFAULT_USER_AGENT
-    );
+/**
+ * Returns the configured User-Agent, or undefined when none is set (in which
+ * case no User-Agent header should be added).
+ */
+function getUserAgent(): string | undefined {
+    return overrideUserAgent ?? process.env.CHIITILER_USER_AGENT;
 }
 
 export { getUserAgent, setUserAgent };


### PR DESCRIPTION
## What

v1.22.0 always sent a `chiitiler (+https://github.com/Kanahiro/chiitiler)` `User-Agent` on outbound HTTP requests, even when the user hadn't configured one. This changes the default back to **not overriding the User-Agent at all** — the runtime's default is used (Node sends `node`) unless one is set explicitly.

Setting a User-Agent is now opt-in via:
- `--user-agent <ua>` CLI flag
- `CHIITILER_USER_AGENT` env var
- `setUserAgent('my-app/1.0')` (library use)

## Why

`chiitiler` shouldn't inject its own identity into requests users make through it. This matches [tileserver-gl](https://github.com/maptiler/tileserver-gl/blob/master/src/serve_rendered.js), which also sets no custom User-Agent on outbound `fetch`.

Note: providers requiring an identifying UA (e.g. OpenStreetMap) now need one set explicitly — `node` alone won't satisfy their tile usage policy.

## Changes
- `userAgent.ts`: `getUserAgent()` returns `string | undefined`; dropped the hardcoded `chiitiler` default
- `http.ts` / `pmtiles.ts`: only attach the `User-Agent` header when one is configured
- Updated test + README

🤖 Generated with [Claude Code](https://claude.com/claude-code)