### PR TITLE
fix: percent-decoded fallback for file:// paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "chiitiler",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "description": "Tiny map rendering server for MapLibre Style Spec",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/source/fs.ts
+++ b/src/source/fs.ts
@@ -1,16 +1,26 @@
-import fs from 'fs';
+import fs from 'node:fs/promises';
 
-function getFilesystemSource(uri: string) {
-    return new Promise<Buffer | null>((resolve, _) => {
-        fs.readFile(uri.replace('file://', ''), (err, data) => {
-            if (err) {
-                console.error(`[ERROR]: ${err}`);
-                resolve(null);
-            } else {
-                resolve(data);
-            }
-        });
-    });
+async function getFilesystemSource(uri: string): Promise<Buffer | null> {
+    const path = uri.replace('file://', '');
+    const data = await fs.readFile(path).catch(() => null);
+    if (data !== null) return data;
+
+    // maplibre-gl-native percent-encodes {fontstack} in glyphs URLs
+    // (e.g. "Noto Sans Regular" -> "Noto%20Sans%20Regular"),
+    // so retry with the percent-decoded path
+    let decodedPath: string;
+    try {
+        decodedPath = decodeURIComponent(path);
+    } catch {
+        decodedPath = path;
+    }
+    if (decodedPath !== path) {
+        const decodedData = await fs.readFile(decodedPath).catch(() => null);
+        if (decodedData !== null) return decodedData;
+    }
+
+    console.error(`[ERROR]: failed to read ${path}`);
+    return null;
 }
 
 export { getFilesystemSource };

--- a/src/source/index.test.ts
+++ b/src/source/index.test.ts
@@ -1,3 +1,7 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
 import { describe, it, expect, vi } from 'vitest';
 
 import { getSource } from './index.js';
@@ -7,6 +11,22 @@ describe('getSource', () => {
         const uri = 'file://localdata/style.json';
         const data = await getSource(uri);
         expect(data).not.toBeNull();
+    });
+
+    it('file:// with percent-encoded path', async () => {
+        // maplibre-gl-native percent-encodes {fontstack} in glyphs URLs
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'chiitiler-'));
+        const fontDir = path.join(dir, 'Noto Sans Regular');
+        fs.mkdirSync(fontDir);
+        fs.writeFileSync(path.join(fontDir, '0-255.pbf'), 'glyph');
+        try {
+            const uri = `file://${dir}/Noto%20Sans%20Regular/0-255.pbf`;
+            const data = await getSource(uri);
+            expect(data).not.toBeNull();
+            expect(data?.toString()).toBe('glyph');
+        } finally {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
     });
 
     it('https://', async () => {


### PR DESCRIPTION
## Summary

Fixes #223

`glyphs` with a `file://` URL failed to resolve when the fontstack name contains spaces (e.g. `Noto Sans Regular`), because maplibre-gl-native percent-encodes the `{fontstack}` placeholder (`Noto%20Sans%20Regular`) and `getFilesystemSource` used the URI verbatim as a filesystem path.

## Changes

- `getFilesystemSource` now reads the raw path first, and if not found, retries with the `decodeURIComponent`-decoded path. Raw-first keeps full backward compatibility for existing paths that literally contain `%XX` sequences; the fallback resolves encoded glyph paths. Malformed sequences (where `decodeURIComponent` throws `URIError`) are caught and skip the retry.
- Rewrote `fs.ts` with `node:fs/promises` instead of a hand-rolled Promise wrapper around callback `fs.readFile`.
- Added a regression test reading a file under a `Noto Sans Regular` directory via a percent-encoded `file://` URI.
- Version bump to v1.22.2.