### PR TITLE
ci: build arm64 image on native ARM runner instead of QEMU

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -4,33 +4,88 @@ on:
     types: [created]
   workflow_dispatch:
 
+env:
+  IMAGE: ghcr.io/kanahiro/chiitiler
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Build each platform natively; Node segfaults under QEMU emulation.
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
       - name: Login GitHub Packages
-        uses: docker/login-action@v1.13.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/amd64,linux/arm64
-          image: tonistiigi/binfmt:qemu-v7.0.0-28
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Build and push Docker image
-        id: build-and-push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
-          tags: ghcr.io/kanahiro/chiitiler:${{ github.event.release.tag_name }}, ghcr.io/kanahiro/chiitiler:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Login GitHub Packages
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          tags="-t ${{ env.IMAGE }}:latest"
+          if [ -n "${{ github.event.release.tag_name }}" ]; then
+            tags="$tags -t ${{ env.IMAGE }}:${{ github.event.release.tag_name }}"
+          fi
+          docker buildx imagetools create $tags \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+      - name: Inspect image
+        run: docker buildx imagetools inspect ${{ env.IMAGE }}:latest

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -4,6 +4,10 @@ on:
     types: [created]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   IMAGE: ghcr.io/kanahiro/chiitiler
 


### PR DESCRIPTION
## 背景

v1.22.3 のリリースビルド ([run](https://github.com/Kanahiro/chiitiler/actions/runs/30098427829)) が linux/arm64 側の `RUN node -e ...` で Segmentation fault (exit 139) して失敗しました。npm install 前の純粋な JS 処理で落ちており、原因は Node 20+ を QEMU エミュレーションで動かすと間欠的に segfault する既知の問題です(17分前の v1.22.2 は同じレイヤーが成功している = フレーク)。

## 変更内容

- QEMU (`docker/setup-qemu-action`) を廃止し、amd64 は `ubuntu-latest`、arm64 は `ubuntu-24.04-arm`(public リポジトリで無料)でそれぞれネイティブビルド
- 各アーキテクチャを push-by-digest でビルドし、`merge` ジョブで `docker buildx imagetools create` により multi-arch マニフェストを作成
- GHA キャッシュはプラットフォームごとに scope を分離
- `workflow_dispatch` 実行時(release tag なし)は `latest` のみタグ付けするように(従来は空タグで壊れる構成だった)
- `docker/login-action` を v1.13.0 → v3 に更新

副次効果として、エミュレーション廃止で arm64 ビルドが大幅に高速化されます。

マージ後、v1.22.3 のイメージは workflow_dispatch では tag が付かないため、失敗した run の re-run(QEMU のフレークなので通る可能性が高い)か、リリースの再作成で発行してください。