### PR TITLE
fix: fail render on upstream 5xx/network errors instead of serving empty tiles (v1.23.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chiitiler",
-  "version": "1.22.3",
+  "version": "1.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chiitiler",
-      "version": "1.22.3",
+      "version": "1.23.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1032.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "chiitiler",
-  "version": "1.22.3",
+  "version": "1.23.0",
   "description": "Tiny map rendering server for MapLibre Style Spec",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/render/pool.ts
+++ b/src/render/pool.ts
@@ -39,8 +39,15 @@ async function getRenderPool(
                                 callback(undefined, EMPTY_RESPONSE);
                             }
                         })
-                        .catch(() => {
-                            callback(undefined, EMPTY_RESPONSE);
+                        .catch((err) => {
+                            // 5xx/ネットワークエラー: 空タイルとして描画すると
+                            // 欠損タイルがCDN等にキャッシュされうるので、
+                            // エラーを渡してレンダリング自体を失敗させる
+                            callback(
+                                err instanceof Error
+                                    ? err
+                                    : new Error(String(err)),
+                            );
                         });
                 },
                 ratio: 1,

--- a/src/source/gcs.ts
+++ b/src/source/gcs.ts
@@ -14,8 +14,11 @@ async function getGCSSource(uri: string) {
         const [buffer] = await file.download();
         return buffer;
     } catch (e: any) {
-        if (e.code !== 404) console.log(e);
-        return null;
+        // 404: オブジェクトが存在しない。空タイルとして扱わせる
+        if (e.code === 404) return null;
+        // それ以外は有無が不明なのでthrowしてレンダリングを失敗させる
+        console.log(e);
+        throw e;
     }
 }
 

--- a/src/source/http.test.ts
+++ b/src/source/http.test.ts
@@ -49,6 +49,30 @@ describe('getHttpSource', () => {
         expect(data).toBeNull();
     });
 
+    it('throws for 5xx to fail rendering instead of drawing an empty tile', async () => {
+        const cache = memoryCache({ ttl: 60, maxItemCount: 10 });
+        const setSpy = vi.spyOn(cache, 'set');
+        mockFetch(new Response('internal server error', { status: 500 }));
+
+        const uri = 'https://example.com/broken.webp';
+        await expect(getHttpSource(uri, cache)).rejects.toThrow(
+            'upstream error 500',
+        );
+        expect(setSpy).not.toHaveBeenCalled();
+    });
+
+    it('throws when fetch fails (server unreachable)', async () => {
+        const cache = memoryCache({ ttl: 60, maxItemCount: 10 });
+        vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+            new TypeError('fetch failed'),
+        );
+
+        const uri = 'https://example.com/unreachable.webp';
+        await expect(getHttpSource(uri, cache)).rejects.toThrow(
+            'failed to fetch',
+        );
+    });
+
     it('does not send a User-Agent header by default', async () => {
         const fetchSpy = mockFetch(
             new Response(new Uint8Array([1]), { status: 200 }),

--- a/src/source/http.ts
+++ b/src/source/http.ts
@@ -13,25 +13,34 @@ async function getHttpSource(
     if (val !== undefined) return val; // hit
 
     // miss
+    let res: Response;
     try {
         const userAgent = getUserAgent();
-        const res = await fetch(uri, {
+        res = await fetch(uri, {
             headers: userAgent ? { 'User-Agent': userAgent } : undefined,
         });
-        if (!res.ok) {
-            console.log(`failed to fetch ${uri}`);
-            return null;
-        }
-        // 204/空ボディはキャッシュ汚染を避けるため書き込まずnullを返す
-        if (res.status === 204) return null;
-        const buf = Buffer.from(await res.arrayBuffer());
-        if (buf.length === 0) return null;
-        cache.set(uri, buf);
-        return buf;
     } catch (e) {
-        console.error(`[ERROR] ${e}`);
+        // ネットワークエラー: タイルの有無が不明なまま透明タイルを返すと
+        // CDN等に欠損タイルがキャッシュされうるので、throwしてレンダリングを失敗させる
+        console.error(`[ERROR] failed to fetch ${uri}: ${e}`);
+        throw new Error(`failed to fetch ${uri}: ${e}`);
+    }
+    if (res.status >= 500) {
+        // 5xx: 一時的な障害でタイルの有無は不明。ネットワークエラーと同様に扱う
+        console.error(`[ERROR] upstream error ${res.status} for ${uri}`);
+        throw new Error(`upstream error ${res.status} for ${uri}`);
+    }
+    if (!res.ok) {
+        // 4xx: タイルが存在しない(404など)。空タイルとして扱わせる
+        console.log(`failed to fetch ${uri}`);
         return null;
     }
+    // 204/空ボディはキャッシュ汚染を避けるため書き込まずnullを返す
+    if (res.status === 204) return null;
+    const buf = Buffer.from(await res.arrayBuffer());
+    if (buf.length === 0) return null;
+    cache.set(uri, buf);
+    return buf;
 }
 
 export { getHttpSource };

--- a/src/source/pmtiles.test.ts
+++ b/src/source/pmtiles.test.ts
@@ -1,0 +1,105 @@
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+import { getPmtilesSource } from './pmtiles.js';
+import { memoryCache } from '../cache/memory.js';
+
+// Serve localdata/school.pmtiles over HTTP with byte-range support (pmtiles
+// requires it) and a switchable failure mode, so we can exercise how the
+// pmtiles source reacts to upstream 5xx.
+const archive = fs.readFileSync(
+    path.join(process.cwd(), 'localdata/school.pmtiles'),
+);
+let mode: 'ok' | '500' | '404' = 'ok';
+let server: http.Server;
+let port = 0;
+
+beforeAll(async () => {
+    server = http.createServer((req, res) => {
+        if (mode === '500') {
+            res.statusCode = 500;
+            res.end('upstream error');
+            return;
+        }
+        if (mode === '404') {
+            res.statusCode = 404;
+            res.end('not found');
+            return;
+        }
+        const range = req.headers.range;
+        if (range) {
+            const m = /bytes=(\d+)-(\d+)/.exec(range)!;
+            const start = Number(m[1]);
+            const end = Number(m[2]);
+            const chunk = archive.subarray(start, end + 1);
+            res.statusCode = 206;
+            res.setHeader('Content-Range', `bytes ${start}-${end}/${archive.length}`);
+            res.setHeader('Content-Length', String(chunk.length));
+            res.setHeader('Accept-Ranges', 'bytes');
+            res.end(chunk);
+            return;
+        }
+        res.setHeader('Content-Length', String(archive.length));
+        res.setHeader('Accept-Ranges', 'bytes');
+        res.end(archive);
+    });
+    await new Promise<void>((resolve) =>
+        server.listen(0, '127.0.0.1', () => {
+            port = (server.address() as import('node:net').AddressInfo).port;
+            resolve();
+        }),
+    );
+});
+
+afterAll(() => {
+    server.close();
+});
+
+// A distinct archive URL per test keeps the module-level pmtilesCache from
+// leaking a resolved archive object between cases.
+const uri = (tag: string, zxy: string) =>
+    `pmtiles://http://127.0.0.1:${port}/school.pmtiles?t=${tag}/${zxy}`;
+
+describe('getPmtilesSource (http)', () => {
+    it('returns a tile that exists in the archive', async () => {
+        mode = 'ok';
+        const cache = memoryCache({ ttl: 60, maxItemCount: 10 });
+        const buf = await getPmtilesSource(uri('exists', '6/57/23'), cache);
+        expect(buf).not.toBeNull();
+        expect(buf!.length).toBeGreaterThan(0);
+    });
+
+    it('returns null for a tile absent from the archive (empty tile)', async () => {
+        mode = 'ok';
+        const cache = memoryCache({ ttl: 60, maxItemCount: 10 });
+        const buf = await getPmtilesSource(uri('sparse', '14/1/1'), cache);
+        expect(buf).toBeNull();
+    });
+
+    it('throws on upstream 5xx instead of returning an empty tile', async () => {
+        mode = '500';
+        const cache = memoryCache({ ttl: 60, maxItemCount: 10 });
+        await expect(
+            getPmtilesSource(uri('err5xx', '6/57/23'), cache),
+        ).rejects.toThrow();
+    });
+
+    it('recovers after a transient header-load failure (no sticky poisoning)', async () => {
+        const cache = memoryCache({ ttl: 60, maxItemCount: 10 });
+        // first request loads the archive header while upstream is failing
+        mode = '500';
+        await expect(
+            getPmtilesSource(uri('recover', '6/57/23'), cache),
+        ).rejects.toThrow();
+
+        // upstream recovers; the failed archive object must not be cached, so
+        // the next request rebuilds it and succeeds
+        mode = 'ok';
+        const buf = await getPmtilesSource(uri('recover', '6/57/23'), cache);
+        expect(buf).not.toBeNull();
+        expect(buf!.length).toBeGreaterThan(0);
+    });
+});

--- a/src/source/pmtiles.ts
+++ b/src/source/pmtiles.ts
@@ -143,10 +143,6 @@ async function getPmtilesSource(
 	}
 
 	const [z, x, y] = uri.replace(`pmtiles://${pmtilesUri}/`, '').split('/');
-	// An upstream 5xx/network error throws out of getZxy and propagates so the
-	// render fails (rather than producing a cacheable empty tile). The cached
-	// PMTiles object is safe to keep: ResolvedValueCache never caches the
-	// failure, so the next request retries cleanly.
 	const tile = await pmtiles.getZxy(Number(z), Number(x), Number(y));
 
 	if (!tile) return null;

--- a/src/source/pmtiles.ts
+++ b/src/source/pmtiles.ts
@@ -137,7 +137,19 @@ async function getPmtilesSource(
 	}
 
 	const [z, x, y] = uri.replace(`pmtiles://${pmtilesUri}/`, '').split('/');
-	const tile = await pmtiles.getZxy(Number(z), Number(x), Number(y));
+	let tile;
+	try {
+		tile = await pmtiles.getZxy(Number(z), Number(x), Number(y));
+	} catch (e) {
+		// pmtiles caches the archive header/directory read as a promise inside
+		// the PMTiles object. A transient failure there (5xx/network) caches a
+		// rejected promise, so this cached object would keep failing even after
+		// the upstream recovers. Drop it so the next request rebuilds it with a
+		// fresh internal cache, then rethrow so the render fails (not an empty
+		// tile that could be cached downstream).
+		pmtilesCache.delete(pmtilesUri);
+		throw e;
+	}
 
 	if (!tile) return null;
 

--- a/src/source/pmtiles.ts
+++ b/src/source/pmtiles.ts
@@ -123,11 +123,6 @@ async function getPmtilesSource(
 			const headers = new Headers();
 			if (userAgent) headers.set('User-Agent', userAgent);
 			const fetchSource = new FetchSource(pmtilesUri, headers);
-			// ResolvedValueCache caches only resolved values; the default
-			// SharedPromiseCache caches the in-flight promise and so keeps a
-			// rejected header/directory read cached, poisoning this object until
-			// eviction. Using ResolvedValueCache lets a transient upstream 5xx
-			// recover on the next request without dropping the cached archive.
 			pmtiles = new PMTiles(fetchSource, new ResolvedValueCache());
 			pmtilesCache.set(pmtilesUri, pmtiles);
 		}

--- a/src/source/pmtiles.ts
+++ b/src/source/pmtiles.ts
@@ -1,6 +1,12 @@
 import * as fs from 'fs';
 
-import { PMTiles, FetchSource, Source, RangeResponse } from 'pmtiles';
+import {
+	PMTiles,
+	FetchSource,
+	ResolvedValueCache,
+	Source,
+	RangeResponse,
+} from 'pmtiles';
 import {
 	GetObjectCommand,
 	GetObjectCommandOutput,
@@ -117,7 +123,12 @@ async function getPmtilesSource(
 			const headers = new Headers();
 			if (userAgent) headers.set('User-Agent', userAgent);
 			const fetchSource = new FetchSource(pmtilesUri, headers);
-			pmtiles = new PMTiles(fetchSource);
+			// ResolvedValueCache caches only resolved values; the default
+			// SharedPromiseCache caches the in-flight promise and so keeps a
+			// rejected header/directory read cached, poisoning this object until
+			// eviction. Using ResolvedValueCache lets a transient upstream 5xx
+			// recover on the next request without dropping the cached archive.
+			pmtiles = new PMTiles(fetchSource, new ResolvedValueCache());
 			pmtilesCache.set(pmtilesUri, pmtiles);
 		}
 	} else if (pmtilesUri.startsWith('s3://')) {
@@ -125,31 +136,23 @@ async function getPmtilesSource(
 			const bucket = pmtilesUri.replace('s3://', '').split('/')[0];
 			const key = pmtilesUri.replace(`s3://${bucket}/`, '');
 			const s3Source = new S3Source(bucket, key);
-			pmtiles = new PMTiles(s3Source);
+			pmtiles = new PMTiles(s3Source, new ResolvedValueCache());
 			pmtilesCache.set(pmtilesUri, pmtiles);
 		}
 	} else {
 		if (pmtiles === undefined) {
 			const fileSource = new FilesystemSource(pmtilesUri);
-			pmtiles = new PMTiles(fileSource);
+			pmtiles = new PMTiles(fileSource, new ResolvedValueCache());
 			pmtilesCache.set(pmtilesUri, pmtiles);
 		}
 	}
 
 	const [z, x, y] = uri.replace(`pmtiles://${pmtilesUri}/`, '').split('/');
-	let tile;
-	try {
-		tile = await pmtiles.getZxy(Number(z), Number(x), Number(y));
-	} catch (e) {
-		// pmtiles caches the archive header/directory read as a promise inside
-		// the PMTiles object. A transient failure there (5xx/network) caches a
-		// rejected promise, so this cached object would keep failing even after
-		// the upstream recovers. Drop it so the next request rebuilds it with a
-		// fresh internal cache, then rethrow so the render fails (not an empty
-		// tile that could be cached downstream).
-		pmtilesCache.delete(pmtilesUri);
-		throw e;
-	}
+	// An upstream 5xx/network error throws out of getZxy and propagates so the
+	// render fails (rather than producing a cacheable empty tile). The cached
+	// PMTiles object is safe to keep: ResolvedValueCache never caches the
+	// failure, so the next request retries cleanly.
+	const tile = await pmtiles.getZxy(Number(z), Number(x), Number(y));
 
 	if (!tile) return null;
 

--- a/src/source/s3.ts
+++ b/src/source/s3.ts
@@ -20,8 +20,12 @@ async function getS3Source(uri: string) {
         const buf = Buffer.from(await obj.Body.transformToByteArray());
         return buf;
     } catch (e: any) {
-        if (e.name !== 'NoSuchKey') console.log(e);
-        return null;
+        // NoSuchKey: オブジェクトが存在しない。空タイルとして扱わせる
+        if (e.name === 'NoSuchKey') return null;
+        // それ以外(スロットリング・ネットワークエラー等)は有無が不明なので
+        // throwしてレンダリングを失敗させる
+        console.log(e);
+        throw e;
     }
 }
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -91,11 +91,11 @@ describe('intergration test', () => {
         expect(await res.text()).toBe('failed to render tile');
     });
 
-    test('POST /tiles with unfetchable raster source -> 200 transparent', async () => {
-        // regression: an empty/unfetchable raster tile must render as a
-        // transparent tile, not fail the whole render. The extension-less
-        // tile URL also covers the path the old transparent-image fallback
-        // could not resolve. 127.0.0.1:1 refuses connection -> source is null.
+    test('POST /tiles with unreachable raster source -> 500', async () => {
+        // 5xx/network errors mean the tile's existence is unknown: rendering
+        // a transparent tile would let CDNs cache a missing-data tile as if
+        // it were valid, so the whole render must fail.
+        // 127.0.0.1:1 refuses connection -> getSource throws.
         const res = await fetch('http://localhost:3000/tiles/0/0/0.png', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -107,6 +107,37 @@ describe('intergration test', () => {
                             type: 'raster',
                             tiles: [
                                 'http://127.0.0.1:1/xyz/{z}/{x}/{y}?format=webp',
+                            ],
+                            tileSize: 256,
+                            maxzoom: 22,
+                        },
+                    },
+                    layers: [{ id: 'r', type: 'raster', source: 'r' }],
+                },
+            }),
+        });
+        expect(res.status).toBe(500);
+        expect(res.headers.get('content-type')).toMatch(/^text\/plain/);
+        expect(await res.text()).toBe('failed to render tile');
+    });
+
+    test('POST /tiles with 404 raster source -> 200 transparent', async () => {
+        // 404 means "no tile there" (normal for sparse tilesets) and must
+        // render as a transparent tile, not fail the whole render. The
+        // extension-less tile URL also covers the path the old
+        // transparent-image fallback could not resolve. The server itself
+        // returns 404 for unknown paths.
+        const res = await fetch('http://localhost:3000/tiles/0/0/0.png', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                style: {
+                    version: 8,
+                    sources: {
+                        r: {
+                            type: 'raster',
+                            tiles: [
+                                'http://localhost:3000/notfound/{z}/{x}/{y}?format=webp',
                             ],
                             tileSize: 256,
                             maxzoom: 22,


### PR DESCRIPTION
## Problem

HTTP source (and S3/GCS) returned `null` for **any** failure, and the render pool treated `null` as an empty/transparent tile served with **HTTP 200**. So when an upstream tile server was down (5xx) or unreachable, chiitiler happily rendered a broken transparent tile. If that response lands in a CDN, the outage gets cached and persists well past upstream recovery — which is exactly the nasty case to avoid.

The root issue is that `Buffer | null` can't distinguish **"the tile does not exist"** (normal, e.g. 404 over ocean in a sparse tileset) from **"a transient failure happened, existence unknown"**.

## Change

Sources now make that distinction:

| Source | "not found" → `null` (empty tile) | "failure" → throw |
|--------|-----------------------------------|-------------------|
| http   | 4xx (404 etc.), 204, empty body   | 5xx, `fetch` rejection (unreachable) |
| s3     | `NoSuchKey`                       | everything else (throttling, network, auth) |
| gcs    | 404                               | everything else |
| pmtiles | tile absent from a valid archive | archive 5xx/404/network (already threw via the lib) |

The render pool now propagates thrown errors via `callback(err)` instead of swallowing them with `EMPTY_RESPONSE`. A failed source makes the whole render fail, and the route responds **500** — which CDNs won't cache. Per discussion, a single failing source fails the entire tile (no partial render).

### pmtiles

`pmtiles` sources already throw on upstream failure — the pmtiles lib does `if (status >= 300) throw "Bad response code"`, and a tile genuinely absent from a valid archive returns `undefined` → `null` (empty tile). So pmtiles was hit by the same original bug (the pool swallowed the throw into a 200 empty tile) and is fixed by the pool change too.

**But** I found a sticky-poisoning issue while verifying this: the default `SharedPromiseCache` inside each `PMTiles` object caches the *in-flight promise* of the archive header/directory read. When that read fails (5xx/network), the **rejected promise stays cached**, so the archive object keeps failing **even after the upstream recovers**, until it is evicted from chiitiler's `pmtilesCache` (LRU) or the process restarts — the in-process analog of the CDN-poisoning problem, and worse because no TTL clears it.

Fix: construct `PMTiles` with **`ResolvedValueCache`**, which caches only *resolved* values (it awaits, then caches on success), so a failed header/directory read is never cached and the next request retries cleanly. This covers all poisoning surfaces (header, root and leaf directories) at the root, so no call-site try/catch or cache eviction is needed. Verified with a runtime probe: with `SharedPromiseCache` the same object stays poisoned after recovery; with `ResolvedValueCache` it recovers.

Trade-off: `ResolvedValueCache` does not dedup concurrent in-flight header fetches the way `SharedPromiseCache` does, so a cold burst to a brand-new archive may each fetch the ~16KB header once. Acceptable for a tile server (one-time per archive, small read).

### Render pool

I verified the mbgl `Map` instance does **not** need to be destroyed after a failed render: it does not negatively-cache the failed tile, so reusing it via `pool.release` is safe (keeps the expensive `Map` init off the failure path). Tested by toggling a mock upstream between 500 and 404 across repeated and concurrent requests — instances are reused (no extra `Map` construction), recovery is immediate, and the process stays healthy.

## Compatibility

**BREAKING CHANGE** → `v1.23.0`

Requests hitting an upstream 5xx or network error now return **500** instead of a **200** transparent tile. Deployments where an S3/GCS misconfiguration or upstream flakiness was silently masked by transparent tiles will start surfacing 500s. This is intended — the failure becomes visible instead of being cached as valid-looking data.

`cog://` is intentionally left as-is: `higuruma` errors don't let us distinguish out-of-range from network failure, so those still fall back to a transparent tile.

## Tests

- Unit (`src/source/http.test.ts`): 5xx throws without caching; `fetch` rejection throws. Existing 404/204/empty-body → `null` cases retained.
- Unit (`src/source/pmtiles.test.ts`, new): serves `localdata/school.pmtiles` over HTTP with byte-range support and a switchable failure mode — tile present → buffer, tile absent → `null`, upstream 5xx → throw, and **recovery after a transient header-load failure** (regression test for the poisoning fix; confirmed it fails if the default `SharedPromiseCache` is restored).
- Integration (`tests/integration.test.ts`): flipped the old "unreachable raster → 200 transparent" expectation to **→ 500**, and added "404 raster → 200 transparent" to lock in the not-found path.
- `npm run check`, 35 unit tests, and 16 integration tests (docker-compose) all pass locally.