### PR TITLE
Fix encoded glyph paths for object storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chiitiler",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chiitiler",
-      "version": "1.23.1",
+      "version": "1.23.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1032.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chiitiler",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chiitiler",
-      "version": "1.23.0",
+      "version": "1.23.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1032.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "chiitiler",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "Tiny map rendering server for MapLibre Style Spec",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "chiitiler",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "description": "Tiny map rendering server for MapLibre Style Spec",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/source/fs.ts
+++ b/src/source/fs.ts
@@ -1,23 +1,13 @@
 import fs from 'node:fs/promises';
 
+import { loadWithDecodedPathFallback } from './path.js';
+
 async function getFilesystemSource(uri: string): Promise<Buffer | null> {
     const path = uri.replace('file://', '');
-    const data = await fs.readFile(path).catch(() => null);
+    const data = await loadWithDecodedPathFallback(path, (candidate) =>
+        fs.readFile(candidate).catch(() => null),
+    );
     if (data !== null) return data;
-
-    // maplibre-gl-native percent-encodes {fontstack} in glyphs URLs
-    // (e.g. "Noto Sans Regular" -> "Noto%20Sans%20Regular"),
-    // so retry with the percent-decoded path
-    let decodedPath: string;
-    try {
-        decodedPath = decodeURIComponent(path);
-    } catch {
-        decodedPath = path;
-    }
-    if (decodedPath !== path) {
-        const decodedData = await fs.readFile(decodedPath).catch(() => null);
-        if (decodedData !== null) return decodedData;
-    }
 
     console.error(`[ERROR]: failed to read ${path}`);
     return null;

--- a/src/source/gcs.test.ts
+++ b/src/source/gcs.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { download, file } = vi.hoisted(() => {
+    const download = vi.fn();
+    return {
+        download,
+        file: vi.fn(() => ({ download })),
+    };
+});
+
+vi.mock('../gcs.js', () => ({
+    getStorageClient: () => ({
+        bucket: () => ({ file }),
+    }),
+}));
+
+import { getGCSSource } from './gcs.js';
+
+describe('getGCSSource', () => {
+    beforeEach(() => {
+        download.mockReset();
+        file.mockClear();
+    });
+
+    it('loads a percent-encoded path using its decoded form first', async () => {
+        download.mockResolvedValueOnce([Buffer.from('glyph')]);
+
+        const result = await getGCSSource(
+            'gs://fonts/Noto%20Sans%20Regular%2CArial/0-255.pbf',
+        );
+
+        expect(result?.toString()).toBe('glyph');
+        expect(file).toHaveBeenCalledOnce();
+        expect(file).toHaveBeenCalledWith(
+            'Noto Sans Regular,Arial/0-255.pbf',
+        );
+    });
+
+    it('does not hide errors other than a missing object', async () => {
+        const error = new Error('network failure');
+        download.mockRejectedValueOnce(error);
+
+        await expect(getGCSSource('gs://fonts/glyph.pbf')).rejects.toBe(error);
+        expect(download).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/source/gcs.ts
+++ b/src/source/gcs.ts
@@ -1,4 +1,5 @@
 import { getStorageClient } from '../gcs.js';
+import { loadWithDecodedPathFallback } from './path.js';
 
 async function getGCSSource(uri: string) {
     const storageClient = getStorageClient({
@@ -9,17 +10,19 @@ async function getGCSSource(uri: string) {
     const bucket = uri.replace('gs://', '').split('/')[0];
     const path = uri.replace(`gs://${bucket}/`, '');
 
-    try {
-        const file = storageClient.bucket(bucket).file(path);
-        const [buffer] = await file.download();
-        return buffer;
-    } catch (e: any) {
-        // 404: オブジェクトが存在しない。空タイルとして扱わせる
-        if (e.code === 404) return null;
-        // それ以外は有無が不明なのでthrowしてレンダリングを失敗させる
-        console.log(e);
-        throw e;
-    }
+    return loadWithDecodedPathFallback(path, async (candidate) => {
+        try {
+            const file = storageClient.bucket(bucket).file(candidate);
+            const [buffer] = await file.download();
+            return buffer;
+        } catch (e: any) {
+            // 404: オブジェクトが存在しない。空タイルとして扱わせる
+            if (e.code === 404) return null;
+            // それ以外は有無が不明なのでthrowしてレンダリングを失敗させる
+            console.log(e);
+            throw e;
+        }
+    });
 }
 
 export { getGCSSource };

--- a/src/source/path.test.ts
+++ b/src/source/path.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { loadWithDecodedPathFallback } from './path.js';
+
+describe('loadWithDecodedPathFallback', () => {
+    it('prefers the decoded form of a percent-encoded path', async () => {
+        const load = vi.fn().mockResolvedValue(Buffer.from('decoded'));
+
+        const result = await loadWithDecodedPathFallback('font%20name', load);
+
+        expect(result?.toString()).toBe('decoded');
+        expect(load).toHaveBeenCalledOnce();
+        expect(load).toHaveBeenCalledWith('font name');
+    });
+
+    it('falls back to an existing literal percent-encoded path', async () => {
+        const load = vi
+            .fn()
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(Buffer.from('literal'));
+
+        const result = await loadWithDecodedPathFallback('font%20name', load);
+
+        expect(result?.toString()).toBe('literal');
+        expect(load.mock.calls).toEqual([['font name'], ['font%20name']]);
+    });
+
+    it('does not retry malformed percent encoding', async () => {
+        const load = vi.fn().mockResolvedValue(null);
+
+        await expect(
+            loadWithDecodedPathFallback('font%ZZname', load),
+        ).resolves.toBeNull();
+        expect(load).toHaveBeenCalledOnce();
+    });
+});

--- a/src/source/path.ts
+++ b/src/source/path.ts
@@ -1,0 +1,24 @@
+/**
+ * Load a percent-decoded path first, then retry its literal form when the
+ * resource is absent. MapLibre Native encodes glyph font stacks before passing
+ * their URLs to the source resolver, while object stores treat keys literally.
+ */
+async function loadWithDecodedPathFallback<T>(
+    path: string,
+    load: (path: string) => Promise<T | null>,
+): Promise<T | null> {
+    let decodedPath: string;
+    try {
+        decodedPath = decodeURIComponent(path);
+    } catch {
+        return load(path);
+    }
+
+    if (decodedPath === path) return load(path);
+
+    const decodedData = await load(decodedPath);
+    if (decodedData !== null) return decodedData;
+    return load(path);
+}
+
+export { loadWithDecodedPathFallback };

--- a/src/source/s3.test.ts
+++ b/src/source/s3.test.ts
@@ -1,0 +1,44 @@
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { send } = vi.hoisted(() => ({ send: vi.fn() }));
+
+vi.mock('../s3.js', () => ({
+    getS3Client: () => ({ send }),
+}));
+
+import { getS3Source } from './s3.js';
+
+describe('getS3Source', () => {
+    beforeEach(() => {
+        send.mockReset();
+    });
+
+    it('loads a percent-encoded key using its decoded form first', async () => {
+        send.mockResolvedValueOnce({
+            Body: {
+                transformToByteArray: async () =>
+                    Uint8Array.from(Buffer.from('glyph')),
+            },
+        });
+
+        const result = await getS3Source(
+            's3://fonts/Noto%20Sans%20Regular%2CArial/0-255.pbf',
+        );
+
+        expect(result?.toString()).toBe('glyph');
+        expect(send).toHaveBeenCalledOnce();
+        expect((send.mock.calls[0][0] as GetObjectCommand).input).toEqual({
+            Bucket: 'fonts',
+            Key: 'Noto Sans Regular,Arial/0-255.pbf',
+        });
+    });
+
+    it('does not hide errors other than a missing key', async () => {
+        const error = new Error('network failure');
+        send.mockRejectedValueOnce(error);
+
+        await expect(getS3Source('s3://fonts/glyph.pbf')).rejects.toBe(error);
+        expect(send).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/source/s3.ts
+++ b/src/source/s3.ts
@@ -1,6 +1,7 @@
 import { GetObjectCommand } from '@aws-sdk/client-s3';
 
 import { getS3Client } from '../s3.js';
+import { loadWithDecodedPathFallback } from './path.js';
 
 async function getS3Source(uri: string) {
     const s3Client = getS3Client({
@@ -10,23 +11,25 @@ async function getS3Source(uri: string) {
     });
     const bucket = uri.replace('s3://', '').split('/')[0];
     const key = uri.replace(`s3://${bucket}/`, '');
-    const cmd = new GetObjectCommand({
-        Bucket: bucket,
-        Key: key,
+
+    return loadWithDecodedPathFallback(key, async (candidate) => {
+        const cmd = new GetObjectCommand({
+            Bucket: bucket,
+            Key: candidate,
+        });
+        try {
+            const obj = await s3Client.send(cmd);
+            if (obj.Body === undefined) return null;
+            return Buffer.from(await obj.Body.transformToByteArray());
+        } catch (e: any) {
+            // NoSuchKey: オブジェクトが存在しない。空タイルとして扱わせる
+            if (e.name === 'NoSuchKey') return null;
+            // それ以外(スロットリング・ネットワークエラー等)は有無が不明なので
+            // throwしてレンダリングを失敗させる
+            console.log(e);
+            throw e;
+        }
     });
-    try {
-        const obj = await s3Client.send(cmd);
-        if (obj.Body === undefined) return null;
-        const buf = Buffer.from(await obj.Body.transformToByteArray());
-        return buf;
-    } catch (e: any) {
-        // NoSuchKey: オブジェクトが存在しない。空タイルとして扱わせる
-        if (e.name === 'NoSuchKey') return null;
-        // それ以外(スロットリング・ネットワークエラー等)は有無が不明なので
-        // throwしてレンダリングを失敗させる
-        console.log(e);
-        throw e;
-    }
 }
 
 export { getS3Source };


### PR DESCRIPTION
## Summary

- decode percent-encoded source paths before loading glyphs from S3 and GCS
- fall back to the literal encoded key when it exists for backward compatibility
- share the path-resolution policy with the existing filesystem source
- add regression coverage for spaces, multi-font commas, malformed encoding, and non-not-found errors

## Root cause

MapLibre Native percent-encodes `{fontstack}` before passing glyph URLs to the source resolver. S3 and GCS treated that encoded value as a literal object key, so font stacks containing spaces or commas could not be found.

Decoded paths are attempted first because they are the normal MapLibre glyph case and avoid an extra not-found request for every glyph range. Literal encoded keys remain available as a fallback.

## Validation

- `npm run check`
- `npm run test:unit -- --run` (42 tests passed)
- `git diff --check`

Closes #235