### PR TITLE
Add prewarm option to warm up renderer at startup (Lambda INIT phase)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,8 @@ RUN npm ci --no-audit --no-fund
 
 FROM gl-base AS runtime
 
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
-ENV PORT=3000
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
+ENV AWS_LWA_PORT=3000
 ENV AWS_LWA_READINESS_CHECK_PATH=/health
 # If prewarm pushes INIT past Lambda's 10s limit, continue it during the
 # first invoke instead of letting Lambda restart the sandbox.

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,9 @@ FROM gl-base AS runtime
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
 ENV PORT=3000
 ENV AWS_LWA_READINESS_CHECK_PATH=/health
+# If prewarm pushes INIT past Lambda's 10s limit, continue it during the
+# first invoke instead of letting Lambda restart the sandbox.
+ENV AWS_LWA_ASYNC_INIT=true
 
 # npm and Corepack are unnecessary at runtime.
 COPY --from=node:24-bookworm-slim /usr/local/bin/node /usr/local/bin/node

--- a/README.md
+++ b/README.md
@@ -122,10 +122,9 @@ All options can be set via CLI flag or environment variable.
 | `--debug` | `CHIITILER_DEBUG` | `false` |
 | `--user-agent <ua>` | `CHIITILER_USER_AGENT` | (none) |
 | `--prewarm` | `CHIITILER_PREWARM` | `false` |
-| `--prewarm-style-url <url>` | `CHIITILER_PREWARM_STYLE_URL` | — (implies prewarm) |
 | — | `CHIITILER_PROCESSES` | `1` (set `0` for all CPUs) |
 
-With prewarm enabled, one tile is rendered at startup **before** the server starts listening, so renderer initialization (GL context, sharp/libvips, JIT) doesn't hit the first request. On AWS Lambda with Lambda Web Adapter, the readiness check keeps this inside the INIT phase, which runs with a full CPU boost. Pass a `style.json` URL to also warm that style's render pool, glyphs and sprites.
+With prewarm enabled, one tile is rendered at startup **before** the server starts listening, so renderer initialization (GL context, sharp/libvips, JIT) doesn't hit the first request. On AWS Lambda with Lambda Web Adapter, the readiness check keeps this inside the INIT phase, which runs with a full CPU boost.
 
 ### Cache
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,11 @@ All options can be set via CLI flag or environment variable.
 | `--port <n>` | `CHIITILER_PORT` | `3000` |
 | `--debug` | `CHIITILER_DEBUG` | `false` |
 | `--user-agent <ua>` | `CHIITILER_USER_AGENT` | (none) |
+| `--prewarm` | `CHIITILER_PREWARM` | `false` |
+| `--prewarm-style-url <url>` | `CHIITILER_PREWARM_STYLE_URL` | — (implies prewarm) |
 | — | `CHIITILER_PROCESSES` | `1` (set `0` for all CPUs) |
+
+With prewarm enabled, one tile is rendered at startup **before** the server starts listening, so renderer initialization (GL context, sharp/libvips, JIT) doesn't hit the first request. On AWS Lambda with Lambda Web Adapter, the readiness check keeps this inside the INIT phase, which runs with a full CPU boost. Pass a `style.json` URL to also warm that style's render pool, glyphs and sprites.
 
 ### Cache
 

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -37,6 +37,10 @@ export class ChiitilerStack extends cdk.Stack {
 					CHIITILER_CACHE_METHOD: 's3', // Use S3 cache
 					CHIITILER_S3CACHE_BUCKET: cacheBucket.bucketName,
 					CHIITILER_S3_REGION: 'ap-northeast-1',
+					// Warm up the renderer during the INIT phase (full CPU
+					// boost). Set CHIITILER_PREWARM_STYLE_URL instead to also
+					// warm a specific style's render pool and its resources.
+					CHIITILER_PREWARM: 'true',
 				},
 			},
 		);

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -33,13 +33,12 @@ export class ChiitilerStack extends cdk.Stack {
 				environment: {
 					// environment variables for chiitiler
 					CHIITILER_PORT: '3000',
-					CHIITILER_STREAM_MODE: 'true', // Enable stream mode for Lambda
+					// must match the Function URL's invokeMode (RESPONSE_STREAM)
+					AWS_LWA_INVOKE_MODE: 'response_stream',
 					CHIITILER_CACHE_METHOD: 's3', // Use S3 cache
 					CHIITILER_S3CACHE_BUCKET: cacheBucket.bucketName,
 					CHIITILER_S3_REGION: 'ap-northeast-1',
-					// Warm up the renderer during the INIT phase (full CPU
-					// boost). Set CHIITILER_PREWARM_STYLE_URL instead to also
-					// warm a specific style's render pool and its resources.
+					// Warm up the renderer during the INIT phase (full CPU boost)
 					CHIITILER_PREWARM: 'true',
 				},
 			},

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -33,8 +33,6 @@ export class ChiitilerStack extends cdk.Stack {
 				environment: {
 					// environment variables for chiitiler
 					CHIITILER_PORT: '3000',
-					// must match the Function URL's invokeMode (RESPONSE_STREAM)
-					AWS_LWA_INVOKE_MODE: 'response_stream',
 					CHIITILER_CACHE_METHOD: 's3', // Use S3 cache
 					CHIITILER_S3CACHE_BUCKET: cacheBucket.bucketName,
 					CHIITILER_S3_REGION: 'ap-northeast-1',
@@ -49,7 +47,7 @@ export class ChiitilerStack extends cdk.Stack {
 		// Create a Function URL for the Lambda function
 		const functionUrl = chiitilerFunction.addFunctionUrl({
 			authType: lambda.FunctionUrlAuthType.NONE, // Public access
-			invokeMode: lambda.InvokeMode.RESPONSE_STREAM,
+			// BUFFERED (default): LWA also runs in buffered mode by default
 		});
 
 		// Output the Function URL

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chiitiler",
-  "version": "1.23.2",
+  "version": "1.23.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chiitiler",
-      "version": "1.23.2",
+      "version": "1.23.3",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1032.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "chiitiler",
-  "version": "1.23.2",
+  "version": "1.23.3",
   "description": "Tiny map rendering server for MapLibre Style Spec",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -104,11 +104,7 @@ describe('run chiitiler', () => {
         }));
 
         const program = createProgram();
-        await program.parseAsync(['node', 'cli.js', 'tile-server', '--prewarm-style-url', 'https://tile.example.com/style.json']); // prettier-ignore
-        expect(prewarm).toHaveBeenCalledWith(
-            expect.anything(),
-            'https://tile.example.com/style.json',
-        );
+        await program.parseAsync(['node', 'cli.js', 'tile-server', '--prewarm']); // prettier-ignore
         expect(callOrder).toEqual(['prewarm', 'start']);
     });
 
@@ -122,7 +118,7 @@ describe('run chiitiler', () => {
 
         const program = createProgram();
         await program.parseAsync(['node', 'cli.js', 'tile-server', '--prewarm']); // prettier-ignore
-        expect(prewarm).toHaveBeenCalledWith(expect.anything(), undefined);
+        expect(prewarm).toHaveBeenCalled();
         expect(start).toHaveBeenCalled();
     });
 });

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,9 +1,17 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { createProgram } from './cli.js';
 import * as server from './server/index.js';
+import { prewarm } from './render/warmup.js';
 
 vi.mock('@maplibre/maplibre-gl-native', () => ({}));
+vi.mock('./render/warmup.js', () => ({
+    prewarm: vi.fn().mockResolvedValue(undefined),
+}));
+
+beforeEach(() => {
+    vi.mocked(prewarm).mockClear();
+});
 
 describe('run chiitiler', () => {
     it('parse options1', async () => {
@@ -68,5 +76,53 @@ describe('run chiitiler', () => {
         const program = createProgram();
         program.parse(['node', 'cli.js', 'tile-server', '-c', 's3']);
         expect(options!.cache.name).toBe('s3');
+    });
+
+    it('no prewarm by default', async () => {
+        const start = vi.fn();
+        vi.spyOn(server, 'initServer').mockImplementation(() => ({
+            app: {} as any,
+            start,
+        }));
+
+        const program = createProgram();
+        await program.parseAsync(['node', 'cli.js', 'tile-server']);
+        expect(prewarm).not.toHaveBeenCalled();
+        expect(start).toHaveBeenCalled();
+    });
+
+    it('prewarm runs before the server starts', async () => {
+        const callOrder: string[] = [];
+        vi.mocked(prewarm).mockImplementation(async () => {
+            callOrder.push('prewarm');
+        });
+        vi.spyOn(server, 'initServer').mockImplementation(() => ({
+            app: {} as any,
+            start: () => {
+                callOrder.push('start');
+            },
+        }));
+
+        const program = createProgram();
+        await program.parseAsync(['node', 'cli.js', 'tile-server', '--prewarm-style-url', 'https://tile.example.com/style.json']); // prettier-ignore
+        expect(prewarm).toHaveBeenCalledWith(
+            expect.anything(),
+            'https://tile.example.com/style.json',
+        );
+        expect(callOrder).toEqual(['prewarm', 'start']);
+    });
+
+    it('prewarm failure does not prevent startup', async () => {
+        vi.mocked(prewarm).mockRejectedValue(new Error('boom'));
+        const start = vi.fn();
+        vi.spyOn(server, 'initServer').mockImplementation(() => ({
+            app: {} as any,
+            start,
+        }));
+
+        const program = createProgram();
+        await program.parseAsync(['node', 'cli.js', 'tile-server', '--prewarm']); // prettier-ignore
+        expect(prewarm).toHaveBeenCalledWith(expect.anything(), undefined);
+        expect(start).toHaveBeenCalled();
     });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -98,18 +98,9 @@ function parsePort(port: string | undefined) {
     return 3000;
 }
 
-function parsePrewarm(
-    prewarmFlag: boolean | undefined,
-    prewarmStyleUrl: string | undefined,
-): { enabled: boolean; styleUrl?: string } {
+function parsePrewarm(prewarmFlag: boolean | undefined) {
     // command-line option, then env
-    const styleUrl =
-        prewarmStyleUrl ?? process.env.CHIITILER_PREWARM_STYLE_URL;
-    const enabled =
-        prewarmFlag === true ||
-        process.env.CHIITILER_PREWARM === 'true' ||
-        styleUrl !== undefined;
-    return { enabled, styleUrl };
+    return prewarmFlag === true || process.env.CHIITILER_PREWARM === 'true';
 }
 
 function parseDebug(debug: boolean | undefined) {
@@ -186,10 +177,6 @@ export function createProgram() {
             '--prewarm',
             'render one tile at startup before listening, to warm up the renderer',
         )
-        .option(
-            '--prewarm-style-url <url>',
-            'style.json url to prewarm with (implies --prewarm)',
-        )
         .option('-D, --debug', 'debug mode')
         .action(async (options) => {
             // env fallback (CHIITILER_USER_AGENT) is handled in userAgent.ts
@@ -232,14 +219,10 @@ export function createProgram() {
             // warm up BEFORE listening: Lambda Web Adapter polls the
             // readiness check until the port opens, so work done here
             // stays inside the INIT phase (full CPU boost)
-            const prewarmOptions = parsePrewarm(
-                options.prewarm,
-                options.prewarmStyleUrl,
-            );
-            if (prewarmOptions.enabled) {
+            if (parsePrewarm(options.prewarm)) {
                 const startedAt = Date.now();
                 try {
-                    await prewarm(serverOptions.cache, prewarmOptions.styleUrl);
+                    await prewarm(serverOptions.cache);
                     console.log(`prewarm done in ${Date.now() - startedAt}ms`);
                 } catch (err) {
                     // 温まらないだけでサーバとしては動けるので起動は続行する

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { Command } from 'commander';
 import { initServer, type InitServerOptions } from './server/index.js';
 import * as caches from './cache/index.js';
 import { setUserAgent } from './source/userAgent.js';
+import { prewarm } from './render/warmup.js';
 
 function parseCacheStrategy(
     method: 'none' | 'memory' | 'file' | 's3' | 'gcs',
@@ -97,6 +98,20 @@ function parsePort(port: string | undefined) {
     return 3000;
 }
 
+function parsePrewarm(
+    prewarmFlag: boolean | undefined,
+    prewarmStyleUrl: string | undefined,
+): { enabled: boolean; styleUrl?: string } {
+    // command-line option, then env
+    const styleUrl =
+        prewarmStyleUrl ?? process.env.CHIITILER_PREWARM_STYLE_URL;
+    const enabled =
+        prewarmFlag === true ||
+        process.env.CHIITILER_PREWARM === 'true' ||
+        styleUrl !== undefined;
+    return { enabled, styleUrl };
+}
+
 function parseDebug(debug: boolean | undefined) {
     // command-line option
     if (debug) return true;
@@ -167,8 +182,16 @@ export function createProgram() {
             '--user-agent <user-agent>',
             'User-Agent header for outbound HTTP requests',
         )
+        .option(
+            '--prewarm',
+            'render one tile at startup before listening, to warm up the renderer',
+        )
+        .option(
+            '--prewarm-style-url <url>',
+            'style.json url to prewarm with (implies --prewarm)',
+        )
         .option('-D, --debug', 'debug mode')
-        .action((options) => {
+        .action(async (options) => {
             // env fallback (CHIITILER_USER_AGENT) is handled in userAgent.ts
             if (options.userAgent !== undefined) setUserAgent(options.userAgent);
 
@@ -204,6 +227,24 @@ export function createProgram() {
                 console.log(
                     `editor page: http://localhost:${serverOptions.port}/editor`,
                 );
+            }
+
+            // warm up BEFORE listening: Lambda Web Adapter polls the
+            // readiness check until the port opens, so work done here
+            // stays inside the INIT phase (full CPU boost)
+            const prewarmOptions = parsePrewarm(
+                options.prewarm,
+                options.prewarmStyleUrl,
+            );
+            if (prewarmOptions.enabled) {
+                const startedAt = Date.now();
+                try {
+                    await prewarm(serverOptions.cache, prewarmOptions.styleUrl);
+                    console.log(`prewarm done in ${Date.now() - startedAt}ms`);
+                } catch (err) {
+                    // 温まらないだけでサーバとしては動けるので起動は続行する
+                    console.warn(`prewarm failed: ${err}`);
+                }
             }
 
             const { start } = initServer(serverOptions);

--- a/src/render/warmup.ts
+++ b/src/render/warmup.ts
@@ -3,7 +3,6 @@ import type { StyleSpecification } from '@maplibre/maplibre-gl-style-spec';
 import { getRenderedTile } from './index.js';
 import type { Cache } from '../cache/index.js';
 
-// 実運用スタイルが指定されないときのフォールバック。
 // スタイル固有のリソース(タイル/glyphs/sprite)は温まらないが、
 // EGL/GLコンテキスト・Xvfb接続・sharp(libvips)・JITの初期化は共通で効く。
 const MINIMAL_STYLE: StyleSpecification = {
@@ -23,13 +22,10 @@ const MINIMAL_STYLE: StyleSpecification = {
  * initialization happens at startup — on AWS Lambda (with Lambda Web
  * Adapter's readiness check) this moves the work into the INIT phase,
  * which runs with a full CPU boost.
- *
- * When styleUrl is given, the style is fetched and its render pool is
- * built, so glyphs/sprite/source fetches for that style are warmed too.
  */
-async function prewarm(cache: Cache, styleUrl?: string): Promise<void> {
+async function prewarm(cache: Cache): Promise<void> {
     const sharp = await getRenderedTile({
-        stylejson: styleUrl ?? MINIMAL_STYLE,
+        stylejson: MINIMAL_STYLE,
         z: 0,
         x: 0,
         y: 0,

--- a/src/render/warmup.ts
+++ b/src/render/warmup.ts
@@ -1,0 +1,45 @@
+import type { StyleSpecification } from '@maplibre/maplibre-gl-style-spec';
+
+import { getRenderedTile } from './index.js';
+import type { Cache } from '../cache/index.js';
+
+// 実運用スタイルが指定されないときのフォールバック。
+// スタイル固有のリソース(タイル/glyphs/sprite)は温まらないが、
+// EGL/GLコンテキスト・Xvfb接続・sharp(libvips)・JITの初期化は共通で効く。
+const MINIMAL_STYLE: StyleSpecification = {
+    version: 8,
+    sources: {},
+    layers: [
+        {
+            id: 'background',
+            type: 'background',
+            paint: { 'background-color': '#ffffff' },
+        },
+    ],
+};
+
+/**
+ * Render one z0 tile ahead of the first request so that renderer
+ * initialization happens at startup — on AWS Lambda (with Lambda Web
+ * Adapter's readiness check) this moves the work into the INIT phase,
+ * which runs with a full CPU boost.
+ *
+ * When styleUrl is given, the style is fetched and its render pool is
+ * built, so glyphs/sprite/source fetches for that style are warmed too.
+ */
+async function prewarm(cache: Cache, styleUrl?: string): Promise<void> {
+    const sharp = await getRenderedTile({
+        stylejson: styleUrl ?? MINIMAL_STYLE,
+        z: 0,
+        x: 0,
+        y: 0,
+        tileSize: 512,
+        cache,
+        margin: 0,
+        ext: 'png',
+        quality: 100,
+    });
+    await sharp.toBuffer(); // force the actual encode
+}
+
+export { prewarm };


### PR DESCRIPTION
## Summary

Move renderer initialization out of the first request and into server startup — on AWS Lambda (with Lambda Web Adapter) this lands in the INIT phase, which runs with a full CPU boost.

- **`--prewarm` / `CHIITILER_PREWARM=true`**: render one z0 tile (minimal inline style) and PNG-encode it before the server starts listening. This initializes the EGL/GL context, the Xvfb connection, sharp/libvips, and JIT-compiles the hot path.
- Prewarm runs **before** `serve()`, so LWA's readiness check (`/health`) only passes after warmup — the work stays inside INIT instead of racing the first request. Prewarm failure logs a warning and startup continues.
- LWA env vars updated to current names (adapter 1.0.1): `PORT` → `AWS_LWA_PORT`, added `AWS_LWA_ASYNC_INIT=true` so a prewarm exceeding Lambda's 10s INIT limit continues into the first invoke instead of restarting the sandbox.
- CDK sample stack: enable `CHIITILER_PREWARM=true`; drop response streaming entirely — remove the unused `CHIITILER_STREAM_MODE` and let the Function URL use the default `BUFFERED` invoke mode, matching LWA's default.
- README documents the new option.

## Test plan

- `npm run check` passes; `cdk`'s `tsc --noEmit` passes.
- New unit tests in `src/cli.test.ts`: prewarm off by default; prewarm runs before `start()`; prewarm failure doesn't prevent startup.
- `vitest src`: 43 passed; the 2 failures in `src/source/index.test.ts` are pre-existing network-dependent tests (fetch `demotiles.maplibre.org`) that can't reach the internet from the sandbox, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129JAYWQhARBfNzzYDQbXAB