### PR TITLE
Bump version to 1.23.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chiitiler",
-  "version": "1.23.3",
+  "version": "1.23.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chiitiler",
-      "version": "1.23.3",
+      "version": "1.23.4",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1032.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "chiitiler",
-  "version": "1.23.3",
+  "version": "1.23.4",
   "description": "Tiny map rendering server for MapLibre Style Spec",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Changes

- Bump package version 1.23.3 → 1.23.4 (`package.json` / `package-lock.json`)

Note: AWS Lambda Web Adapter is already pinned to `1.0.1` in the Dockerfile (`public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1`), which is the latest LWA release — no change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T16dV1QzHDWeQTZ19NHYCh

---
_Generated by [Claude Code](https://claude.ai/code/session_01T16dV1QzHDWeQTZ19NHYCh)_