### PR TITLE
Isolate render modes and deduplicate PMTiles metadata (v1.23.8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chiitiler",
-  "version": "1.23.7",
+  "version": "1.23.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chiitiler",
-      "version": "1.23.7",
+      "version": "1.23.8",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1131.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "chiitiler",
-  "version": "1.23.7",
+  "version": "1.23.8",
   "description": "Tiny map rendering server for MapLibre Style Spec",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/render/pool.test.ts
+++ b/src/render/pool.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { StyleSpecification } from '@maplibre/maplibre-gl-style-spec';
+
+import { getRenderPool } from './pool.js';
+import { noneCache } from '../cache/index.js';
+
+vi.mock('@maplibre/maplibre-gl-native', () => ({
+    default: {
+        Map: class {
+            constructor(public options: { mode: string }) {}
+            load() {}
+            release() {}
+        },
+    },
+}));
+
+describe('getRenderPool', () => {
+    it.each(['tile', 'static'] as const)(
+        'keeps modes separate when %s is requested first',
+        async (firstMode) => {
+            const style: StyleSpecification = {
+                version: 8,
+                name: firstMode,
+                sources: {},
+                layers: [],
+            };
+            const cache = noneCache();
+            const secondMode = firstMode === 'tile' ? 'static' : 'tile';
+            const first = await getRenderPool(style, cache, firstMode);
+            const second = await getRenderPool(style, cache, secondMode);
+            try {
+                expect(second).not.toBe(first);
+                expect(await getRenderPool(structuredClone(style), cache, firstMode)).toBe(first);
+                expect(await getRenderPool(style, cache, secondMode)).toBe(second);
+
+                for (const [pool, mode] of [[first, firstMode], [second, secondMode]] as const) {
+                    const map = await pool.acquire();
+                    try {
+                        expect(map).toHaveProperty('options.mode', mode);
+                    } finally {
+                        pool.release(map);
+                    }
+                }
+            } finally {
+                await first.close();
+                await second.close();
+            }
+        },
+    );
+});

--- a/src/render/pool.ts
+++ b/src/render/pool.ts
@@ -21,7 +21,8 @@ async function getRenderPool(
     cache: Cache,
     mode: 'tile' | 'static',
 ) {
-    const cacheKey = JSON.stringify(style);
+    // A Map's mode is fixed at creation; tile and static requests cannot share it.
+    const cacheKey = `${mode}:${JSON.stringify(style)}`;
 
     const pool = mapPoolCache.get(cacheKey);
     if (pool !== undefined) return pool;

--- a/src/source/pmtiles.test.ts
+++ b/src/source/pmtiles.test.ts
@@ -16,9 +16,13 @@ const archive = fs.readFileSync(
 let mode: 'ok' | '500' | '404' = 'ok';
 let server: http.Server;
 let port = 0;
+const headerRequests: string[] = [];
 
 beforeAll(async () => {
     server = http.createServer((req, res) => {
+        if (req.headers.range?.startsWith('bytes=0-')) {
+            headerRequests.push(req.url!);
+        }
         if (mode === '500') {
             res.statusCode = 500;
             res.end('upstream error');
@@ -64,6 +68,23 @@ const uri = (tag: string, zxy: string) =>
     `pmtiles://http://127.0.0.1:${port}/school.pmtiles?t=${tag}/${zxy}`;
 
 describe('getPmtilesSource (http)', () => {
+    it('shares a cold archive header across concurrent requests for different tiles', async () => {
+        mode = 'ok';
+        const cache = memoryCache({ ttl: 60, maxItemCount: 10 });
+        const tiles = ['0/0/0', '6/57/23'];
+        const results = await Promise.all(
+            tiles.map((tile) => getPmtilesSource(uri('concurrent', tile), cache)),
+        );
+        expect(headerRequests.filter((url) => url.includes('t=concurrent'))).toHaveLength(1);
+        for (const [index, tile] of tiles.entries()) {
+            expect(results[index]).not.toBeNull();
+            expect(results[index]!.length).toBeGreaterThan(0);
+            expect(results[index]).toEqual(
+                await getPmtilesSource(uri('sequential', tile)),
+            );
+        }
+    });
+
     it('returns a tile that exists in the archive', async () => {
         mode = 'ok';
         const cache = memoryCache({ ttl: 60, maxItemCount: 10 });

--- a/src/source/pmtiles.ts
+++ b/src/source/pmtiles.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import {
 	PMTiles,
 	FetchSource,
-	ResolvedValueCache,
+	SharedPromiseCache,
 	Source,
 	RangeResponse,
 } from 'pmtiles';
@@ -117,13 +117,15 @@ async function getPmtilesSource(
 	if (isHttpSource) {
 		const val = await cache.get(uri);
 		if (val !== undefined) return val; // hit
+		// Another request may have created the archive while cache.get awaited.
+		pmtiles = pmtilesCache.get(pmtilesUri);
 
 		if (pmtiles === undefined) {
 			const userAgent = getUserAgent();
 			const headers = new Headers();
 			if (userAgent) headers.set('User-Agent', userAgent);
 			const fetchSource = new FetchSource(pmtilesUri, headers);
-			pmtiles = new PMTiles(fetchSource, new ResolvedValueCache());
+			pmtiles = new PMTiles(fetchSource, new SharedPromiseCache());
 			pmtilesCache.set(pmtilesUri, pmtiles);
 		}
 	} else if (pmtilesUri.startsWith('s3://')) {
@@ -131,19 +133,24 @@ async function getPmtilesSource(
 			const bucket = pmtilesUri.replace('s3://', '').split('/')[0];
 			const key = pmtilesUri.replace(`s3://${bucket}/`, '');
 			const s3Source = new S3Source(bucket, key);
-			pmtiles = new PMTiles(s3Source, new ResolvedValueCache());
+			pmtiles = new PMTiles(s3Source, new SharedPromiseCache());
 			pmtilesCache.set(pmtilesUri, pmtiles);
 		}
 	} else {
 		if (pmtiles === undefined) {
 			const fileSource = new FilesystemSource(pmtilesUri);
-			pmtiles = new PMTiles(fileSource, new ResolvedValueCache());
+			pmtiles = new PMTiles(fileSource, new SharedPromiseCache());
 			pmtilesCache.set(pmtilesUri, pmtiles);
 		}
 	}
 
 	const [z, x, y] = uri.replace(`pmtiles://${pmtilesUri}/`, '').split('/');
-	const tile = await pmtiles.getZxy(Number(z), Number(x), Number(y));
+	const tile = await pmtiles.getZxy(Number(z), Number(x), Number(y)).catch((err) => {
+		// SharedPromiseCache retains rejected metadata promises. Rebuild after a
+		// failure, without evicting a replacement created by a newer request.
+		if (pmtilesCache.get(pmtilesUri) === pmtiles) pmtilesCache.delete(pmtilesUri);
+		throw err;
+	});
 
 	if (!tile) return null;
 


### PR DESCRIPTION
Render pools were keyed only by style, so whichever request arrived first could force later tile or static requests to use the wrong Map mode. Key pools by style and mode, preserving reuse within each mode.

Use SharedPromiseCache for HTTP, S3, and filesystem PMTiles metadata so concurrent tile requests can share header and directory fetches. Recheck the archive cache after the asynchronous HTTP tile-cache lookup to avoid duplicate archive instances, and evict failed instances so rejected metadata promises do not prevent recovery. Bump the package and lockfile from 1.23.7 to 1.23.8.

Validation:
- TypeScript check and production build passed.
- All 7 tests in src/render/pool.test.ts and src/source/pmtiles.test.ts passed: both mode request orders, pool reuse, one header fetch across concurrent different-tile requests, tile contents, missing tiles, and recovery after upstream failure.
- git diff --check passed.

Production latency improvements have not been measured.
