### PR TITLE
Add configurable memory front cache for source assets

### DIFF
--- a/.github/workflows/test:benchmark.yml
+++ b/.github/workflows/test:benchmark.yml
@@ -22,6 +22,10 @@ permissions:
     contents: read
     pull-requests: write
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 jobs:
     benchmark:
         runs-on: ubuntu-24.04
@@ -73,9 +77,14 @@ jobs:
 
             - name: Run paired benchmarks
               run: xvfb-run -a node --import tsx tests/run-benchmark-comparison.ts
+              env:
+                  # Balance both execution orders for quick PR feedback; manual runs retain more samples.
+                  CHIITILER_BENCH_ROUNDS: ${{ github.event_name == 'pull_request' && '2' || '5' }}
+                  CHIITILER_BENCH_DURATION: ${{ github.event_name == 'pull_request' && '5' || '10' }}
+                  CHIITILER_BENCH_WARMUP: '3'
 
             - name: Post results to PR
-              if: always() && github.event_name == 'pull_request' && hashFiles('benchmark-results/benchmark.md') != ''
+              if: ${{ !cancelled() && github.event_name == 'pull_request' && hashFiles('benchmark-results/benchmark.md') != '' }}
               uses: marocchino/sticky-pull-request-comment@v2
               with:
                   header: benchmark

--- a/README.md
+++ b/README.md
@@ -194,13 +194,16 @@ already use the cache, not direct `s3://`, `gs://`, or local source reads.
 
 Set `CHIITILER_FRONT_CACHE_TTL_SEC` to a positive, finite number of seconds and
 `CHIITILER_FRONT_CACHE_MAX_BYTES` to a positive integer number of bytes to override
-these limits. Invalid values stop startup when using `file`, `s3`, or `gcs`.
+these limits. Setting either variable to `0` disables the front cache and uses the
+backing cache directly. Otherwise, invalid values stop startup when using `file`,
+`s3`, or `gcs`.
 These settings do not affect `none`, `memory`, or library callers.
 
 The front-cache TTL does not guarantee source freshness: promotion can retain a
 value for up to the configured TTL beyond its backing-cache expiry, and the S3/GCS cache
 implementations do not check expiry on reads. Each worker has its own memory limit.
-Library callers can opt in and customize the limits:
+Library callers can opt in and customize the limits (either limit set to `0`
+returns the backing cache unchanged):
 
 ```ts
 const cache = ChiitilerCache.withMemoryCache(

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ Prewarm is enabled by default: one tile is rendered at startup **before** the se
 | `--cache <none\|memory\|file\|s3\|gcs>` | `CHIITILER_CACHE_METHOD` | `none` |
 | `--cache-ttl <seconds>` | `CHIITILER_CACHE_TTL_SEC` | `3600` |
 | `--memory-cache-max-item-count <n>` | `CHIITILER_MEMORYCACHE_MAXITEMCOUNT` | `1000` |
+| — | `CHIITILER_FRONT_CACHE_TTL_SEC` | `10` (seconds) |
+| — | `CHIITILER_FRONT_CACHE_MAX_BYTES` | `67108864` (64 MiB) |
 | `--file-cache-dir <dir>` | `CHIITILER_FILECACHE_DIR` | `./.cache` |
 | `--s3-cache-bucket <name>` | `CHIITILER_S3CACHE_BUCKET` | — |
 | `--s3-region <region>` | `CHIITILER_S3_REGION` | `us-east-1` |
@@ -182,6 +184,30 @@ Prewarm is enabled by default: one tile is rendered at startup **before** the se
 | `--gcs-api-endpoint <url>` | `CHIITILER_GCS_API_ENDPOINT` | — |
 
 Chiitiler caches *source assets* (vector tiles, glyphs, sprites) — not final rasters — so cached data is reused across requests. Standard AWS / GCP credentials (`AWS_ACCESS_KEY_ID`, `GOOGLE_APPLICATION_CREDENTIALS`, etc.) are respected.
+
+The tile server adds a per-process memory front cache to `file`, `s3`, and `gcs`:
+by default, buffers are retained for 10 seconds from insertion, with an LRU limit of 64 MiB
+of buffer payloads (JavaScript overhead is additional). Reads promote backing-cache
+hits into memory; writes populate memory immediately and also write to the backing
+cache. `none` and `memory` keep their existing behavior. This affects sources that
+already use the cache, not direct `s3://`, `gs://`, or local source reads.
+
+Set `CHIITILER_FRONT_CACHE_TTL_SEC` to a positive, finite number of seconds and
+`CHIITILER_FRONT_CACHE_MAX_BYTES` to a positive integer number of bytes to override
+these limits. Invalid values stop startup when using `file`, `s3`, or `gcs`.
+These settings do not affect `none`, `memory`, or library callers.
+
+The front-cache TTL does not guarantee source freshness: promotion can retain a
+value for up to the configured TTL beyond its backing-cache expiry, and the S3/GCS cache
+implementations do not check expiry on reads. Each worker has its own memory limit.
+Library callers can opt in and customize the limits:
+
+```ts
+const cache = ChiitilerCache.withMemoryCache(
+    ChiitilerCache.fileCache({ dir: './.cache', ttl: 3600 }),
+    { ttlSeconds: 10, maxBytes: 64 * 1024 * 1024 },
+);
+```
 
 ## Deployment
 

--- a/bench/BENCHMARK.md
+++ b/bench/BENCHMARK.md
@@ -81,11 +81,17 @@ server code and dependencies come from each extracted commit. Thus dependency
 changes are included, while fixture changes are applied equally to both sides.
 Each server runs with the harness working directory so relative fixture paths match.
 
-Five pairs run sequentially on one runner, alternating base/current and
-current/base order. Each measurement starts a fresh server and runs the five
-scenarios in a fixed order, with 3 seconds of warmup and 10 seconds of measurement
-per scenario. Renderer and style caches remain warm within a run even with
-source cache disabled. Nominal load time is about 11 minutes, plus setup/startup.
+PR runs use two pairs on one runner, alternating base/current and current/base
+order. Each measurement starts a fresh server and runs all five scenarios in a
+fixed order, with 3 seconds of warmup and 5 seconds of measurement per scenario.
+Nominal load time is 160 seconds, plus setup/startup (roughly 3–4 minutes total,
+depending on the runner). A new push cancels the previous benchmark for that PR.
+
+Manual workflow runs retain five pairs and 10 seconds of measurement with the
+same 3-second warmup: 650 seconds of load, plus setup/startup. Use these longer
+runs to investigate small differences; the short PR run is a coarse performance
+check with fewer samples. Renderer and style caches remain warm within a run
+even with source cache disabled.
 
 The PR comment shows median throughput/latencies, the median **paired** throughput
 percentage change, its observed min/max and the count of faster pairs. The range

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chiitiler",
-  "version": "1.23.8",
+  "version": "1.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chiitiler",
-      "version": "1.23.8",
+      "version": "1.24.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1131.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "chiitiler",
-  "version": "1.23.8",
+  "version": "1.24.0",
   "description": "Tiny map rendering server for MapLibre Style Spec",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/cache/front.test.ts
+++ b/src/cache/front.test.ts
@@ -103,8 +103,15 @@ describe('withMemoryCache', () => {
     });
 
     it.each([
-        { ttlSeconds: 0 }, { ttlSeconds: -1 }, { ttlSeconds: Infinity },
-        { maxBytes: 0 }, { maxBytes: -1 }, { maxBytes: 1.5 },
+        { ttlSeconds: 0 }, { maxBytes: 0 }, { ttlSeconds: 0, maxBytes: 0 },
+    ])('returns the backing cache unchanged when disabled: %j', (options) => {
+        const backing = backingCache();
+        expect(withMemoryCache(backing, options)).toBe(backing);
+    });
+
+    it.each([
+        { ttlSeconds: -1 }, { ttlSeconds: Infinity },
+        { maxBytes: -1 }, { maxBytes: 1.5 },
     ])('rejects invalid limits %j', (options) => {
         expect(() => withMemoryCache(backingCache(), options)).toThrow();
     });

--- a/src/cache/front.test.ts
+++ b/src/cache/front.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { withMemoryCache } from './front.js';
+import type { Cache, Value } from './index.js';
+
+function backingCache() {
+    return {
+        name: 'test',
+        get: vi.fn<Cache['get']>().mockResolvedValue(undefined),
+        set: vi.fn<Cache['set']>().mockResolvedValue(undefined),
+    };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('withMemoryCache', () => {
+    it('promotes backing hits and expires from insertion, not last access', async () => {
+        // lru-cache retains the performance object at module load time.
+        let now = 1;
+        vi.spyOn(performance, 'now').mockImplementation(() => now);
+        const backing = backingCache();
+        backing.get.mockResolvedValue(Buffer.from('old'));
+        const cache = withMemoryCache(backing);
+        expect(await cache.get('key')).toEqual(Buffer.from('old'));
+        now += 9000;
+        expect(await cache.get('key')).toEqual(Buffer.from('old'));
+        expect(backing.get).toHaveBeenCalledTimes(1);
+        backing.get.mockResolvedValue(Buffer.from('new'));
+        now += 1001;
+        expect(await cache.get('key')).toEqual(Buffer.from('new'));
+        expect(backing.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('shares concurrent reads and does not retain misses or errors', async () => {
+        const backing = backingCache();
+        const cache = withMemoryCache(backing);
+        expect(await Promise.all([cache.get('key'), cache.get('key')])).toEqual([undefined, undefined]);
+        expect(backing.get).toHaveBeenCalledTimes(1);
+        backing.get.mockRejectedValueOnce(new Error('temporary'));
+        await expect(cache.get('key')).rejects.toThrow('temporary');
+        backing.get.mockResolvedValue(Buffer.from('recovered'));
+        expect(await cache.get('key')).toEqual(Buffer.from('recovered'));
+        expect(backing.get).toHaveBeenCalledTimes(3);
+    });
+
+    it('serves writes immediately while backing persistence is pending', async () => {
+        const backing = backingCache();
+        let finish!: () => void;
+        backing.set.mockImplementation(() => new Promise<void>((resolve) => { finish = resolve; }));
+        const cache = withMemoryCache(backing);
+        const value = Buffer.from('value');
+        const writing = cache.set('key', value);
+        expect(await cache.get('key')).toBe(value);
+        expect(backing.get).not.toHaveBeenCalled();
+        expect(backing.set).toHaveBeenCalledWith('key', value);
+        finish();
+        await writing;
+    });
+
+    it('does not let an older backing read overwrite a newer write', async () => {
+        const backing = backingCache();
+        let finish!: (value: Value) => void;
+        backing.get.mockImplementation(() => new Promise<Value>((resolve) => { finish = resolve; }));
+        const cache = withMemoryCache(backing);
+        const reading = cache.get('key');
+        await cache.set('key', Buffer.from('new'));
+        finish(Buffer.from('old'));
+        await reading;
+        expect(await cache.get('key')).toEqual(Buffer.from('new'));
+    });
+
+    it('evicts the least recently used payload to stay within the byte limit', async () => {
+        const backing = backingCache();
+        const cache = withMemoryCache(backing, { maxBytes: 6 });
+        await cache.set('a', Buffer.from('aaa'));
+        await cache.set('b', Buffer.from('bbb'));
+        await cache.get('a');
+        await cache.set('c', Buffer.from('ccc'));
+        expect(await cache.get('a')).toEqual(Buffer.from('aaa'));
+        expect(await cache.get('c')).toEqual(Buffer.from('ccc'));
+        expect(await cache.get('b')).toBeUndefined();
+        expect(backing.get).toHaveBeenCalledExactlyOnceWith('b');
+    });
+
+    it('persists oversized values without retaining an older cached value', async () => {
+        const backing = backingCache();
+        const cache = withMemoryCache(backing, { maxBytes: 3 });
+        await cache.set('key', Buffer.from('old'));
+        const large = Buffer.from('large');
+        await cache.set('key', large);
+        backing.get.mockResolvedValue(large);
+        expect(await cache.get('key')).toBe(large);
+        expect(await cache.get('key')).toBe(large);
+        expect(backing.get).toHaveBeenCalledTimes(2);
+        expect(backing.set).toHaveBeenLastCalledWith('key', large);
+    });
+
+    it('propagates persistence failures while retaining the fetched buffer', async () => {
+        const backing = backingCache();
+        backing.set.mockRejectedValue(new Error('write failed'));
+        const cache = withMemoryCache(backing);
+        await expect(cache.set('key', Buffer.from('value'))).rejects.toThrow('write failed');
+        expect(await cache.get('key')).toEqual(Buffer.from('value'));
+    });
+
+    it.each([
+        { ttlSeconds: 0 }, { ttlSeconds: -1 }, { ttlSeconds: Infinity },
+        { maxBytes: 0 }, { maxBytes: -1 }, { maxBytes: 1.5 },
+    ])('rejects invalid limits %j', (options) => {
+        expect(() => withMemoryCache(backingCache(), options)).toThrow();
+    });
+});

--- a/src/cache/front.ts
+++ b/src/cache/front.ts
@@ -1,0 +1,52 @@
+import { LRUCache } from 'lru-cache';
+import type { Cache, Value } from './index.js';
+
+/**
+ * Keep recent source buffers in this process to avoid backing-cache I/O.
+ * TTL starts on insertion, so promotion can extend the backing cache's lifetime
+ * by up to ttlSeconds. maxBytes bounds buffer payloads, not total process memory.
+ */
+export function withMemoryCache(
+    backing: Cache,
+    { ttlSeconds = 10, maxBytes = 64 * 1024 * 1024 } = {},
+): Cache {
+    if (!Number.isFinite(ttlSeconds) || ttlSeconds <= 0) {
+        throw new Error('ttlSeconds must be positive and finite');
+    }
+    if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) {
+        throw new Error('maxBytes must be a positive safe integer');
+    }
+    const memory = new LRUCache<string, Value>({
+        maxSize: maxBytes,
+        sizeCalculation: (value) => Math.max(1, value.byteLength),
+        ttl: ttlSeconds * 1000,
+        ttlResolution: 0,
+    });
+    const reads = new Map<string, Promise<Value | undefined>>();
+
+    return {
+        name: backing.name,
+        get: async (key) => {
+            const hit = memory.get(key);
+            if (hit !== undefined) return hit;
+            const pending = reads.get(key);
+            if (pending !== undefined) return pending;
+
+            const read = backing.get(key).then((value) => {
+                // A newer write must not be overwritten by an older read.
+                if (value !== undefined && reads.get(key) === read) memory.set(key, value);
+                return value;
+            }).finally(() => {
+                if (reads.get(key) === read) reads.delete(key);
+            });
+            reads.set(key, read);
+            return read;
+        },
+        set: async (key, value) => {
+            reads.delete(key);
+            // Populate before awaiting persistence; callers may not await set.
+            memory.set(key, value);
+            await backing.set(key, value);
+        },
+    };
+}

--- a/src/cache/front.ts
+++ b/src/cache/front.ts
@@ -5,11 +5,14 @@ import type { Cache, Value } from './index.js';
  * Keep recent source buffers in this process to avoid backing-cache I/O.
  * TTL starts on insertion, so promotion can extend the backing cache's lifetime
  * by up to ttlSeconds. maxBytes bounds buffer payloads, not total process memory.
+ * Either limit set to zero disables the front cache and returns backing unchanged.
  */
 export function withMemoryCache(
     backing: Cache,
     { ttlSeconds = 10, maxBytes = 64 * 1024 * 1024 } = {},
 ): Cache {
+    if (ttlSeconds === 0 || maxBytes === 0) return backing;
+
     if (!Number.isFinite(ttlSeconds) || ttlSeconds <= 0) {
         throw new Error('ttlSeconds must be positive and finite');
     }

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -3,6 +3,8 @@ import { s3Cache } from './s3.js';
 import { gcsCache } from './gcs.js';
 import { fileCache } from './file.js';
 
+export { withMemoryCache } from './front.js';
+
 type Value = Buffer;
 type Cache = {
     name: string;

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -51,12 +51,10 @@ describe('run chiitiler', () => {
     });
 
     it.each([
-        ['CHIITILER_FRONT_CACHE_TTL_SEC', '0', 'ttlSeconds'],
         ['CHIITILER_FRONT_CACHE_TTL_SEC', '-1', 'ttlSeconds'],
         ['CHIITILER_FRONT_CACHE_TTL_SEC', 'invalid', 'ttlSeconds'],
         ['CHIITILER_FRONT_CACHE_TTL_SEC', 'Infinity', 'ttlSeconds'],
         ['CHIITILER_FRONT_CACHE_MAX_BYTES', '', 'maxBytes'],
-        ['CHIITILER_FRONT_CACHE_MAX_BYTES', '0', 'maxBytes'],
         ['CHIITILER_FRONT_CACHE_MAX_BYTES', '1.5', 'maxBytes'],
         ['CHIITILER_FRONT_CACHE_MAX_BYTES', 'invalid', 'maxBytes'],
     ])('rejects invalid %s=%s before startup', async (env, value, error) => {
@@ -71,6 +69,21 @@ describe('run chiitiler', () => {
         expect(init).not.toHaveBeenCalled();
         expect(prewarm).not.toHaveBeenCalled();
     });
+
+    it.each(['CHIITILER_FRONT_CACHE_TTL_SEC', 'CHIITILER_FRONT_CACHE_MAX_BYTES'])(
+        'disables the front cache when %s is zero', async (env) => {
+            vi.stubEnv(env, '0');
+            const backing = { name: 'file', get: vi.fn(), set: vi.fn() };
+            vi.spyOn(caches, 'fileCache').mockReturnValue(backing);
+            let options!: server.InitServerOptions;
+            vi.spyOn(server, 'initServer').mockImplementation((opts) => {
+                options = opts;
+                return { app: {} as any, start: vi.fn() };
+            });
+            await createProgram().parseAsync(['node', 'cli.js', 'tile-server', '-c', 'file']);
+            expect(options.cache).toBe(backing);
+        },
+    );
 
     it.each(['file', 's3', 'gcs', 'none', 'memory'] as const)(
         'adds the memory front cache only for I/O-backed caches: %s',

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createProgram } from './cli.js';
 import * as server from './server/index.js';
 import { prewarm } from './render/warmup.js';
+import * as caches from './cache/index.js';
 
 vi.mock('@maplibre/maplibre-gl-native', () => ({}));
 vi.mock('./render/warmup.js', () => ({
@@ -12,6 +13,8 @@ vi.mock('./render/warmup.js', () => ({
 beforeEach(() => {
     vi.mocked(prewarm).mockReset().mockResolvedValue(undefined);
     vi.stubEnv('CHIITILER_PREWARM', undefined);
+    vi.stubEnv('CHIITILER_FRONT_CACHE_TTL_SEC', undefined);
+    vi.stubEnv('CHIITILER_FRONT_CACHE_MAX_BYTES', undefined);
 });
 
 afterEach(() => {
@@ -20,6 +23,80 @@ afterEach(() => {
 });
 
 describe('run chiitiler', () => {
+    it('applies front-cache TTL and byte limits from the environment', async () => {
+        vi.stubEnv('CHIITILER_CACHE_METHOD', 'file');
+        vi.stubEnv('CHIITILER_FRONT_CACHE_TTL_SEC', '2');
+        vi.stubEnv('CHIITILER_FRONT_CACHE_MAX_BYTES', '6');
+        let now = 1;
+        vi.spyOn(performance, 'now').mockImplementation(() => now);
+        const backing = {
+            name: 'file',
+            get: vi.fn().mockResolvedValue(undefined),
+            set: vi.fn().mockResolvedValue(undefined),
+        };
+        vi.spyOn(caches, 'fileCache').mockReturnValue(backing);
+        let options!: server.InitServerOptions;
+        vi.spyOn(server, 'initServer').mockImplementation((opts) => {
+            options = opts;
+            return { app: {} as any, start: vi.fn() };
+        });
+        await createProgram().parseAsync(['node', 'cli.js', 'tile-server']);
+        await options.cache.set('a', Buffer.from('aaa'));
+        await options.cache.set('b', Buffer.from('bbbb'));
+        expect(await options.cache.get('a')).toBeUndefined();
+        expect(await options.cache.get('b')).toEqual(Buffer.from('bbbb'));
+        now += 2001;
+        expect(await options.cache.get('b')).toBeUndefined();
+        expect(backing.get.mock.calls).toEqual([['a'], ['b']]);
+    });
+
+    it.each([
+        ['CHIITILER_FRONT_CACHE_TTL_SEC', '0', 'ttlSeconds'],
+        ['CHIITILER_FRONT_CACHE_TTL_SEC', '-1', 'ttlSeconds'],
+        ['CHIITILER_FRONT_CACHE_TTL_SEC', 'invalid', 'ttlSeconds'],
+        ['CHIITILER_FRONT_CACHE_TTL_SEC', 'Infinity', 'ttlSeconds'],
+        ['CHIITILER_FRONT_CACHE_MAX_BYTES', '', 'maxBytes'],
+        ['CHIITILER_FRONT_CACHE_MAX_BYTES', '0', 'maxBytes'],
+        ['CHIITILER_FRONT_CACHE_MAX_BYTES', '1.5', 'maxBytes'],
+        ['CHIITILER_FRONT_CACHE_MAX_BYTES', 'invalid', 'maxBytes'],
+    ])('rejects invalid %s=%s before startup', async (env, value, error) => {
+        vi.stubEnv(env, value);
+        vi.spyOn(caches, 'fileCache').mockReturnValue({
+            name: 'file', get: vi.fn(), set: vi.fn(),
+        });
+        const init = vi.spyOn(server, 'initServer');
+        await expect(createProgram().parseAsync([
+            'node', 'cli.js', 'tile-server', '-c', 'file',
+        ])).rejects.toThrow(error);
+        expect(init).not.toHaveBeenCalled();
+        expect(prewarm).not.toHaveBeenCalled();
+    });
+
+    it.each(['file', 's3', 'gcs', 'none', 'memory'] as const)(
+        'adds the memory front cache only for I/O-backed caches: %s',
+        async (method) => {
+            const factory = method === 'none' ? 'noneCache' : `${method}Cache` as const;
+            const backing = {
+                name: method,
+                get: vi.fn().mockResolvedValue(Buffer.from('value')),
+                set: vi.fn().mockResolvedValue(undefined),
+            };
+            vi.spyOn(caches, factory).mockReturnValue(backing);
+            vi.stubEnv('CHIITILER_CACHE_METHOD', undefined);
+            let options!: server.InitServerOptions;
+            vi.spyOn(server, 'initServer').mockImplementation((opts) => {
+                options = opts;
+                return { app: {} as any, start: vi.fn() };
+            });
+            await createProgram().parseAsync(['node', 'cli.js', 'tile-server', '-c', method]);
+            await options.cache.get('key');
+            await options.cache.get('key');
+            expect(backing.get).toHaveBeenCalledTimes(
+                ['file', 's3', 'gcs'].includes(method) ? 1 : 2,
+            );
+        },
+    );
+
     it('parse options1', async () => {
         let options: server.InitServerOptions | undefined;
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -200,6 +200,15 @@ export function createProgram() {
                 debug: parseDebug(options.debug),
             };
 
+            if (['file', 's3', 'gcs'].includes(serverOptions.cache.name)) {
+                const ttl = process.env.CHIITILER_FRONT_CACHE_TTL_SEC;
+                const size = process.env.CHIITILER_FRONT_CACHE_MAX_BYTES;
+                serverOptions.cache = caches.withMemoryCache(serverOptions.cache, {
+                    ttlSeconds: ttl === undefined ? undefined : Number(ttl),
+                    maxBytes: size === undefined ? undefined : Number(size),
+                });
+            }
+
             if (serverOptions.debug) {
                 console.log(
                     `running server: http://localhost:${serverOptions.port}`,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -204,8 +204,8 @@ export function createProgram() {
                 const ttl = process.env.CHIITILER_FRONT_CACHE_TTL_SEC;
                 const size = process.env.CHIITILER_FRONT_CACHE_MAX_BYTES;
                 serverOptions.cache = caches.withMemoryCache(serverOptions.cache, {
-                    ttlSeconds: ttl === undefined ? undefined : Number(ttl),
-                    maxBytes: size === undefined ? undefined : Number(size),
+                    ttlSeconds: ttl === undefined ? undefined : Number(ttl.trim() || NaN),
+                    maxBytes: size === undefined ? undefined : Number(size.trim() || NaN),
                 });
             }
 

--- a/tests/compare-benchmarks.ts
+++ b/tests/compare-benchmarks.ts
@@ -56,6 +56,7 @@ export function compare(report: Report): { valid: boolean; markdown: string } {
             `Baseline \`${m.baseline}\` → current \`${m.current}\`. ${m.rounds} pairs, alternating execution order.`,
             `${m.duration}s measurement + ${m.warmup}s warmup per scenario. Node ${m.node}; ${m.platform}/${m.arch}; ${m.cpu ?? 'unknown CPU'} (${m.cpus} logical CPUs).`, '',
             'Values are medians across runs. Δ is the median of paired percentage changes; range is the observed min…max, not a confidence interval. p99 is diagnostic only and omitted if any run has fewer than 100 responses. Minimum responses is the smallest per-run count on each side. No automatic performance gate.', '',
+            ...(m.rounds < 5 ? ['Short run: few measurement pairs. Use the longer manual workflow to investigate small differences.', ''] : []),
             '| Scenario | Req/s base → current | Paired Req/s Δ (range) | Faster pairs | Min responses base → current | p50 ms base → current | p99 ms base → current |',
             '|---|---:|---:|---:|---:|---:|---:|'];
         for (const scenario of pairs[0]!.baseline) {


### PR DESCRIPTION
Repeated source-asset requests currently read from file, S3, or GCS even when the same buffer was just fetched. Add a per-process memory front cache to these tile-server cache backends, defaulting to a 10-second TTL and 64 MiB of buffer payloads.

The cache promotes backing hits, populates memory before awaiting writes, shares concurrent reads, and prevents older reads from overwriting newer writes. TTL is measured from insertion and LRU eviction enforces the payload limit. None and memory cache modes retain their existing behavior.

Expose CHIITILER_FRONT_CACHE_TTL_SEC and CHIITILER_FRONT_CACHE_MAX_BYTES, returning the backing cache unchanged when either is zero and validating positive limits before startup. Empty environment values remain invalid. Export withMemoryCache for library callers and document defaults, configuration, and freshness semantics. Promotion may extend retention beyond backing-cache expiry by the configured TTL; the size limit excludes JavaScript overhead. This caches source assets, not rendered images.

Validation:
- npm run check passed.
- All 43 tests in src/cache and src/cli.test.ts passed, covering expiration, eviction, oversized values, concurrent reads/writes, error recovery, environment configuration, zero-limit disabling, and invalid settings.
- npm run build passed before the zero-limit follow-up; type checks and all 43 relevant tests were rerun after it.
- git diff --check passed.

Production latency improvements have not been measured.
