### PR TITLE
v1.24.1: align CLI flags with environment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,12 @@ All options can be set via CLI flag or environment variable.
 | `--port <n>` | `CHIITILER_PORT` | `3000` |
 | `--debug` | `CHIITILER_DEBUG` | `false` |
 | `--user-agent <ua>` | `CHIITILER_USER_AGENT` | (none) |
-| — | `CHIITILER_PREWARM` | `true` |
-| — | `CHIITILER_PROCESSES` | `1` (set `0` for all CPUs) |
+| `--prewarm [true\|false]` | `CHIITILER_PREWARM` | `true` |
+| `--processes <n>` | `CHIITILER_PROCESSES` | `1` (set `0` for all CPUs) |
 
-Prewarm is enabled by default: one tile is rendered at startup **before** the server starts listening, moving shared renderer initialization work into startup. Either `--no-prewarm` or `CHIITILER_PREWARM=false` disables it. Style-specific tiles, glyphs, and sprites are not preloaded.
+Prewarm is enabled by default: one tile is rendered at startup **before** the server starts listening, moving shared renderer initialization work into startup. `--prewarm false` or `CHIITILER_PREWARM=false` disables it. `--prewarm` alone enables it. The CLI flag takes precedence over the environment variable. Style-specific tiles, glyphs, and sprites are not preloaded.
+
+`--processes` takes precedence over `CHIITILER_PROCESSES` and accepts non-negative integers; `0` uses all available CPUs.
 
 ### Cache
 
@@ -170,8 +172,8 @@ Prewarm is enabled by default: one tile is rendered at startup **before** the se
 | `--cache <none\|memory\|file\|s3\|gcs>` | `CHIITILER_CACHE_METHOD` | `none` |
 | `--cache-ttl <seconds>` | `CHIITILER_CACHE_TTL_SEC` | `3600` |
 | `--memory-cache-max-item-count <n>` | `CHIITILER_MEMORYCACHE_MAXITEMCOUNT` | `1000` |
-| — | `CHIITILER_FRONT_CACHE_TTL_SEC` | `10` (seconds) |
-| — | `CHIITILER_FRONT_CACHE_MAX_BYTES` | `67108864` (64 MiB) |
+| `--front-cache-ttl-sec <seconds>` | `CHIITILER_FRONT_CACHE_TTL_SEC` | `10` (seconds) |
+| `--front-cache-max-bytes <bytes>` | `CHIITILER_FRONT_CACHE_MAX_BYTES` | `67108864` (64 MiB) |
 | `--file-cache-dir <dir>` | `CHIITILER_FILECACHE_DIR` | `./.cache` |
 | `--s3-cache-bucket <name>` | `CHIITILER_S3CACHE_BUCKET` | — |
 | `--s3-region <region>` | `CHIITILER_S3_REGION` | `us-east-1` |
@@ -192,9 +194,9 @@ hits into memory; writes populate memory immediately and also write to the backi
 cache. `none` and `memory` keep their existing behavior. This affects sources that
 already use the cache, not direct `s3://`, `gs://`, or local source reads.
 
-Set `CHIITILER_FRONT_CACHE_TTL_SEC` to a positive, finite number of seconds and
-`CHIITILER_FRONT_CACHE_MAX_BYTES` to a positive integer number of bytes to override
-these limits. Setting either variable to `0` disables the front cache and uses the
+Set `--front-cache-ttl-sec` / `CHIITILER_FRONT_CACHE_TTL_SEC` to a positive, finite number of seconds and
+`--front-cache-max-bytes` / `CHIITILER_FRONT_CACHE_MAX_BYTES` to a positive integer number of bytes to override
+these limits. CLI flags take precedence over environment variables. Setting either limit to `0` disables the front cache and uses the
 backing cache directly. Otherwise, invalid values stop startup when using `file`,
 `s3`, or `gcs`.
 These settings do not affect `none`, `memory`, or library callers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chiitiler",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chiitiler",
-      "version": "1.24.0",
+      "version": "1.24.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1131.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "chiitiler",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "Tiny map rendering server for MapLibre Style Spec",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,18 +1,26 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
+import cluster from 'node:cluster';
+import { availableParallelism } from 'node:os';
+
 import { createProgram } from './cli.js';
 import * as server from './server/index.js';
 import { prewarm } from './render/warmup.js';
 import * as caches from './cache/index.js';
 
 vi.mock('@maplibre/maplibre-gl-native', () => ({}));
+vi.mock('node:cluster', () => ({
+    default: { get isPrimary() { return true; }, fork: vi.fn() },
+}));
 vi.mock('./render/warmup.js', () => ({
     prewarm: vi.fn().mockResolvedValue(undefined),
 }));
 
 beforeEach(() => {
+    vi.mocked(cluster.fork).mockReset();
     vi.mocked(prewarm).mockReset().mockResolvedValue(undefined);
     vi.stubEnv('CHIITILER_PREWARM', undefined);
+    vi.stubEnv('CHIITILER_PROCESSES', undefined);
     vi.stubEnv('CHIITILER_FRONT_CACHE_TTL_SEC', undefined);
     vi.stubEnv('CHIITILER_FRONT_CACHE_MAX_BYTES', undefined);
 });
@@ -23,10 +31,10 @@ afterEach(() => {
 });
 
 describe('run chiitiler', () => {
-    it('applies front-cache TTL and byte limits from the environment', async () => {
+    it.each([false, true])('applies front-cache limits with CLI override=%s', async (useFlags) => {
         vi.stubEnv('CHIITILER_CACHE_METHOD', 'file');
-        vi.stubEnv('CHIITILER_FRONT_CACHE_TTL_SEC', '2');
-        vi.stubEnv('CHIITILER_FRONT_CACHE_MAX_BYTES', '6');
+        vi.stubEnv('CHIITILER_FRONT_CACHE_TTL_SEC', useFlags ? 'invalid' : '2');
+        vi.stubEnv('CHIITILER_FRONT_CACHE_MAX_BYTES', useFlags ? 'invalid' : '6');
         let now = 1;
         vi.spyOn(performance, 'now').mockImplementation(() => now);
         const backing = {
@@ -40,7 +48,9 @@ describe('run chiitiler', () => {
             options = opts;
             return { app: {} as any, start: vi.fn() };
         });
-        await createProgram().parseAsync(['node', 'cli.js', 'tile-server']);
+        await createProgram().parseAsync(['node', 'cli.js', 'tile-server',
+            ...(useFlags ? ['--front-cache-ttl-sec', '2', '--front-cache-max-bytes', '6'] : []),
+        ]);
         await options.cache.set('a', Buffer.from('aaa'));
         await options.cache.set('b', Buffer.from('bbbb'));
         expect(await options.cache.get('a')).toBeUndefined();
@@ -69,6 +79,32 @@ describe('run chiitiler', () => {
         expect(init).not.toHaveBeenCalled();
         expect(prewarm).not.toHaveBeenCalled();
     });
+
+    it.each([
+        ['--front-cache-ttl-sec', '-1', 'ttlSeconds'],
+        ['--front-cache-ttl-sec', 'invalid', 'ttlSeconds'],
+        ['--front-cache-max-bytes', '1.5', 'maxBytes'],
+        ['--front-cache-max-bytes', '', 'maxBytes'],
+    ])('rejects invalid %s=%s', async (flag, value, error) => {
+        vi.spyOn(caches, 'fileCache').mockReturnValue({ name: 'file', get: vi.fn(), set: vi.fn() });
+        const init = vi.spyOn(server, 'initServer');
+        await expect(createProgram().parseAsync([
+            'node', 'cli.js', 'tile-server', '-c', 'file', flag, value,
+        ])).rejects.toThrow(error);
+        expect(init).not.toHaveBeenCalled();
+    });
+
+    it.each(['--front-cache-ttl-sec', '--front-cache-max-bytes'])(
+        'disables the front cache with %s=0 despite the environment', async (flag) => {
+            vi.stubEnv('CHIITILER_FRONT_CACHE_TTL_SEC', '10');
+            vi.stubEnv('CHIITILER_FRONT_CACHE_MAX_BYTES', '1024');
+            const backing = { name: 'file', get: vi.fn(), set: vi.fn() };
+            vi.spyOn(caches, 'fileCache').mockReturnValue(backing);
+            const init = vi.spyOn(server, 'initServer').mockReturnValue({ app: {} as any, start: vi.fn() });
+            await createProgram().parseAsync(['node', 'cli.js', 'tile-server', '-c', 'file', flag, '0']);
+            expect(init.mock.calls[0]![0].cache).toBe(backing);
+        },
+    );
 
     it.each(['CHIITILER_FRONT_CACHE_TTL_SEC', 'CHIITILER_FRONT_CACHE_MAX_BYTES'])(
         'disables the front cache when %s is zero', async (env) => {
@@ -109,6 +145,47 @@ describe('run chiitiler', () => {
             );
         },
     );
+
+    it.each([
+        { env: undefined, flags: [], count: 1 },
+        { env: '2', flags: [], count: 2 },
+        { env: '0', flags: [], count: availableParallelism() },
+        { env: '2', flags: ['--processes', '1'], count: 1 },
+        { env: 'invalid', flags: ['--processes', '3'], count: 3 },
+        { env: '2', flags: ['--processes', '0'], count: availableParallelism() },
+    ])('processes env=$env flags=$flags', async ({ env, flags, count }) => {
+        vi.stubEnv('CHIITILER_PROCESSES', env);
+        vi.spyOn(cluster, 'isPrimary', 'get').mockReturnValue(true);
+        const fork = vi.spyOn(cluster, 'fork').mockReturnValue({} as any);
+        const init = vi.spyOn(server, 'initServer').mockReturnValue({ app: {} as any, start: vi.fn() });
+        await createProgram().parseAsync(['node', 'cli.js', 'tile-server', ...flags]);
+        expect(fork).toHaveBeenCalledTimes(count === 1 ? 0 : count);
+        expect(init).toHaveBeenCalledTimes(count === 1 ? 1 : 0);
+        expect(prewarm).toHaveBeenCalledTimes(count === 1 ? 1 : 0);
+    });
+
+    it('starts a cluster worker without forking again', async () => {
+        vi.spyOn(cluster, 'isPrimary', 'get').mockReturnValue(false);
+        const fork = vi.spyOn(cluster, 'fork').mockReturnValue({} as any);
+        const init = vi.spyOn(server, 'initServer').mockReturnValue({ app: {} as any, start: vi.fn() });
+        await createProgram().parseAsync(['node', 'cli.js', 'tile-server', '--processes', '2']);
+        expect(fork).not.toHaveBeenCalled();
+        expect(init).toHaveBeenCalledOnce();
+    });
+
+    it.each(['-1', '1.5', '', 'invalid', 'Infinity'])('rejects invalid process count %s', async (value) => {
+        const fork = vi.spyOn(cluster, 'fork');
+        const program = createProgram().commands[0]!.exitOverride().configureOutput({ writeErr: () => {} });
+        await expect(program.parseAsync(['node', 'cli.js', '--processes', value]))
+            .rejects.toThrow('processes must be a non-negative safe integer');
+        expect(fork).not.toHaveBeenCalled();
+    });
+
+    it('rejects the removed --no-prewarm flag', async () => {
+        const program = createProgram().commands[0]!.exitOverride().configureOutput({ writeErr: () => {} });
+        await expect(program.parseAsync(['node', 'cli.js', '--no-prewarm']))
+            .rejects.toThrow("unknown option '--no-prewarm'");
+    });
 
     it('parse options1', async () => {
         let options: server.InitServerOptions | undefined;
@@ -175,12 +252,14 @@ describe('run chiitiler', () => {
     });
 
     it.each([
+        { env: 'false', flags: ['--prewarm'], enabled: true },
+        { env: 'false', flags: ['--prewarm', 'true'], enabled: true },
         { env: undefined, flags: [], enabled: true },
         { env: 'true', flags: [], enabled: true },
         { env: 'false', flags: [], enabled: false },
-        { env: undefined, flags: ['--no-prewarm'], enabled: false },
-        { env: 'true', flags: ['--no-prewarm'], enabled: false },
-        { env: 'false', flags: ['--no-prewarm'], enabled: false },
+        { env: undefined, flags: ['--prewarm', 'false'], enabled: false },
+        { env: 'true', flags: ['--prewarm', 'false'], enabled: false },
+        { env: 'false', flags: ['--prewarm', 'false'], enabled: false },
     ])('prewarm env=$env flags=$flags enabled=$enabled', async ({ env, flags, enabled }) => {
         vi.stubEnv('CHIITILER_PREWARM', env);
         const start = vi.fn();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 import process from 'node:process';
+import cluster from 'node:cluster';
+import { availableParallelism } from 'node:os';
 
-import { Command } from 'commander';
+import { Command, Option, InvalidArgumentError } from 'commander';
 
 import { initServer, type InitServerOptions } from './server/index.js';
 import * as caches from './cache/index.js';
@@ -98,9 +100,12 @@ function parsePort(port: string | undefined) {
     return 3000;
 }
 
-function parsePrewarm(prewarmFlag: boolean | undefined) {
-    // Commander defaults a negated option to true; either opt-out disables warmup.
-    return prewarmFlag !== false && process.env.CHIITILER_PREWARM !== 'false';
+function parseProcesses(value: string) {
+    const count = Number(value.trim() || NaN);
+    if (!Number.isSafeInteger(count) || count < 0) {
+        throw new InvalidArgumentError('processes must be a non-negative safe integer');
+    }
+    return count;
 }
 
 function parseDebug(debug: boolean | undefined) {
@@ -173,9 +178,23 @@ export function createProgram() {
             '--user-agent <user-agent>',
             'User-Agent header for outbound HTTP requests',
         )
-        .option('--no-prewarm', 'disable startup renderer warmup (enabled by default)')
+        .addOption(new Option('--prewarm [boolean]', 'startup renderer warmup')
+            .choices(['true', 'false']).preset('true').env('CHIITILER_PREWARM').default('true'))
+        .addOption(new Option('--processes <n>', 'worker processes (0 for all CPUs)')
+            .env('CHIITILER_PROCESSES').argParser(parseProcesses).default(1))
+        .addOption(new Option('--front-cache-ttl-sec <seconds>', 'memory front cache TTL (0 to disable)')
+            .env('CHIITILER_FRONT_CACHE_TTL_SEC'))
+        .addOption(new Option('--front-cache-max-bytes <bytes>', 'memory front cache byte limit (0 to disable)')
+            .env('CHIITILER_FRONT_CACHE_MAX_BYTES'))
         .option('-D, --debug', 'debug mode')
         .action(async (options) => {
+            const numProcesses = options.processes === 0 ? availableParallelism() : options.processes;
+            if (cluster.isPrimary && numProcesses !== 1) {
+                // Workers inherit argv and env, and initialize their own renderer and cache.
+                for (let i = 0; i < numProcesses; i++) cluster.fork();
+                return;
+            }
+
             // env fallback (CHIITILER_USER_AGENT) is handled in userAgent.ts
             if (options.userAgent !== undefined) setUserAgent(options.userAgent);
 
@@ -201,8 +220,8 @@ export function createProgram() {
             };
 
             if (['file', 's3', 'gcs'].includes(serverOptions.cache.name)) {
-                const ttl = process.env.CHIITILER_FRONT_CACHE_TTL_SEC;
-                const size = process.env.CHIITILER_FRONT_CACHE_MAX_BYTES;
+                const ttl = options.frontCacheTtlSec;
+                const size = options.frontCacheMaxBytes;
                 serverOptions.cache = caches.withMemoryCache(serverOptions.cache, {
                     ttlSeconds: ttl === undefined ? undefined : Number(ttl.trim() || NaN),
                     maxBytes: size === undefined ? undefined : Number(size.trim() || NaN),
@@ -225,7 +244,7 @@ export function createProgram() {
             // warm up BEFORE listening: Lambda Web Adapter polls the
             // readiness check until the port opens, so work done here
             // stays inside the INIT phase (full CPU boost)
-            if (parsePrewarm(options.prewarm)) {
+            if (options.prewarm === 'true') {
                 const startedAt = Date.now();
                 try {
                     await prewarm(serverOptions.cache);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,21 +1,8 @@
-import cluster from 'node:cluster';
-import { availableParallelism } from 'node:os';
 import process from 'node:process';
 
 import { createProgram } from './cli.js';
 
-const program = createProgram();
-
-const numProcesses = (() => {
-    if (process.env.CHIITILER_PROCESSES === undefined) return 1;
-    const processesEnv = Number(process.env.CHIITILER_PROCESSES);
-    if (processesEnv === 0) return availableParallelism();
-    else return processesEnv;
-})();
-
-if (cluster.isPrimary && numProcesses !== 1) {
-    // Fork workers.
-    for (let i = 0; i < numProcesses; i++) cluster.fork();
-} else {
-    program.parse(process.argv);
-}
+createProgram().parseAsync(process.argv).catch((error: unknown) => {
+    console.error(error);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
Add CLI options for settings previously available only through environment variables, with CLI values taking precedence:

- Replace `--no-prewarm` with `--prewarm [true|false]`; keep warmup enabled by default.
- Add `--processes <n>`, parsing configuration before forking workers (`0` uses all available CPUs).
- Add `--front-cache-ttl-sec <seconds>` and `--front-cache-max-bytes <bytes>`, retaining existing cache defaults and zero-to-disable behavior.

Update configuration documentation and bump the package and lockfile versions to 1.24.1. Existing uses of `--no-prewarm` must switch to `--prewarm false`.

## Validation
- All 103 unit tests pass, including CLI/environment precedence, worker startup, invalid values, and front-cache limits.
- `npm run check`
- `npm run build`
- `git diff --check`
