### PR TITLE
Retain idle renderer Maps for reuse (v1.24.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ Prewarm is enabled by default: one tile is rendered at startup **before** the se
 
 ### Cache
 
+Renderer Maps are reused per style and rendering mode without an idle timeout.
+They are released when their pool is evicted from the 10-entry LRU or explicitly
+closed. This avoids repeated initialization after quiet periods, at the cost of
+retaining native renderer memory between requests.
+
 | Flag | Env | Default |
 | --- | --- | --- |
 | `--cache <none\|memory\|file\|s3\|gcs>` | `CHIITILER_CACHE_METHOD` | `none` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chiitiler",
-  "version": "1.24.1",
+  "version": "1.24.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chiitiler",
-      "version": "1.24.1",
+      "version": "1.24.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1131.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "chiitiler",
-  "version": "1.24.1",
+  "version": "1.24.2",
   "description": "Tiny map rendering server for MapLibre Style Spec",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/render/pool.test.ts
+++ b/src/render/pool.test.ts
@@ -15,6 +15,53 @@ vi.mock('@maplibre/maplibre-gl-native', () => ({
 }));
 
 describe('getRenderPool', () => {
+    it('reuses a Map after a long idle period and releases it on close', async () => {
+        vi.useFakeTimers();
+        const style: StyleSpecification = {
+            version: 8, name: 'long-idle', sources: {}, layers: [],
+        };
+        const pool = await getRenderPool(style, noneCache(), 'tile');
+        try {
+            const map = await pool.acquire();
+            const release = vi.spyOn(map, 'release');
+            pool.release(map);
+            await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+            expect(release).not.toHaveBeenCalled();
+            const reused = await pool.acquire();
+            pool.release(reused);
+            expect(reused).toBe(map);
+            const closing = pool.close();
+            await vi.advanceTimersByTimeAsync(100);
+            await closing;
+            expect(release).toHaveBeenCalledTimes(1);
+        } finally {
+            const closing = pool.close();
+            await vi.advanceTimersByTimeAsync(100);
+            await closing;
+            vi.useRealTimers();
+        }
+    });
+
+    it('still releases Maps when their style/mode pool is evicted from the LRU', async () => {
+        const cache = noneCache();
+        const style: StyleSpecification = {
+            version: 8, name: 'eviction-victim', sources: {}, layers: [],
+        };
+        const victim = await getRenderPool(style, cache, 'tile');
+        const pools = [victim];
+        try {
+            const map = await victim.acquire();
+            const release = vi.spyOn(map, 'release');
+            victim.release(map);
+            for (let i = 0; i < 10; i++) {
+                pools.push(await getRenderPool({ ...style, name: `eviction-${i}` }, cache, 'tile'));
+            }
+            await vi.waitFor(() => expect(release).toHaveBeenCalledTimes(1));
+        } finally {
+            await Promise.all(pools.map((pool) => pool.close()));
+        }
+    });
+
     it.each(['tile', 'static'] as const)(
         'keeps modes separate when %s is requested first',
         async (firstMode) => {

--- a/src/render/pool.ts
+++ b/src/render/pool.ts
@@ -61,6 +61,10 @@ async function getRenderPool(
         destroy: (map: mbgl.Map) => {
             map.release();
         },
+    }, {
+        // Keep initialized Maps until their pool is evicted or closed. Disable
+        // idle housekeeping rather than running a timer in warm Lambda environments.
+        houseKeepInterval: 0,
     });
     mapPoolCache.set(cacheKey, newPool);
     return newPool;


### PR DESCRIPTION
Renderer Maps were destroyed after 30 idle seconds by lightning-pool's default housekeeping, even while their style/mode pool remained cached. Disable idle housekeeping so initialized Maps survive quiet periods and can be reused by later requests, including requests in reused Lambda environments.

LRU eviction and explicit pool closure still release Maps. Document the resulting native-memory retention and bump package.json and package-lock.json from 1.24.1 to 1.24.2.

Validation:
- npm run check passed.
- All 4 render-pool tests passed. Tests use mocked Maps and the real pool to verify reuse after one simulated idle hour, release on close and LRU eviction, and separation of tile/static modes.
- npm run build passed.
- Staged diff whitespace check passed.

Lambda latency improvements have not been measured.
